### PR TITLE
refactor location-based matching, make structure clear and easy to use

### DIFF
--- a/graph/time_cluster.go
+++ b/graph/time_cluster.go
@@ -11,6 +11,10 @@ import (
 	"Vacation-planner/iowrappers"
 )
 
+type ClusterManager interface{
+	PlaceSearch(string, uint, string) // location, search radius and search type
+}
+
 // TimeCluster consists of a set of Places and a time interval
 type TimeCluster struct {
 	Places       []POI.Place
@@ -34,7 +38,7 @@ func (cls *TimeClusters) Size() int{
 }
 
 //TimeClustersManager
-//To use a TimeClustersManager, fetch Places data using GetPlaces and then time clustering with TimeClustering method.
+//To use a TimeClustersManager, fetch Places data using PlaceSearch and then time clustering with Clustering method.
 type TimeClustersManager struct{
 	Client        *iowrappers.MapsClient
 	TimeClusters  *TimeClusters
@@ -60,7 +64,7 @@ func (placeManager *TimeClustersManager) Init(client *iowrappers.MapsClient, pla
 }
 
 // call Google API to obtain nearby Places and extract location data
-func (placeManager *TimeClustersManager) GetPlaces(location string, searchRadius uint, searchType string){
+func (placeManager *TimeClustersManager) PlaceSearch(location string, searchRadius uint, searchType string){
 	request := iowrappers.PlaceSearchRequest{
 		Location: location,
 		PlaceCat: placeManager.PlaceCat,
@@ -76,7 +80,7 @@ func (placeManager *TimeClustersManager) GetPlaces(location string, searchRadius
 }
 
 // assign Places to time Clusters using their time interval info
-func (placeManager *TimeClustersManager) TimeClustering(day POI.Weekday) {
+func (placeManager *TimeClustersManager) Clustering(day POI.Weekday) {
 	for _, place := range placeManager.places{
 		placeManager.assign(&place, day)
 	}

--- a/matching/matcher.go
+++ b/matching/matcher.go
@@ -101,8 +101,8 @@ func (matcher *TimeMatcher) placeSearch(req *TimeMatchingRequest, placeCat POI.P
 
 	// this is how to use TimeClustersManager
 	mgr.Init(mapsClient, placeCat, intervals, req.Weekday)
-	mgr.GetPlaces(req.Location, req.Radius, "")
-	mgr.TimeClustering(req.Weekday)
+	mgr.PlaceSearch(req.Location, req.Radius, "")
+	mgr.Clustering(req.Weekday)
 
 	return
 }

--- a/test/find_cluster_center_test.go
+++ b/test/find_cluster_center_test.go
@@ -23,7 +23,7 @@ func TestFindClusterCenter (t *testing.T){
 
 	placeClusters := graph.PlaceClusters{}
 	mgr.PlaceClusters = &placeClusters
-	mgr.PlaceClusters.Clusters = make([]graph.Cluster, 3)
+	mgr.PlaceClusters.Clusters = make([]graph.BasicCluster, 3)
 
 	centers := mgr.FindClusterCenter(&geolocations, &clusterResult, &clusterSizes)
 	fmt.Println(centers)


### PR DESCRIPTION
Make method name as close to the design doc as possible, but not interfaced yet.

Location clustering facilities might still be useful for us in the future. Now it is as simple as make a request and call the matching function.

Usage example:
	client := &iowrappers.MapsClient{}
	err := client.Create(apiKey)
	utils.CheckErr(err)

	lm := matching.LocationMatcher{}
	LA := "34.052235,-118.243683"
	req := &matching.LocationMatchingRequest{LA, 1000, 3}

	res := lm.Matching(req, client)
	for _, val := range res{
		fmt.Println(val)
	}
