### PR TITLE
refactor POI.Place to allow BSON export

### DIFF
--- a/POI/places.go
+++ b/POI/places.go
@@ -18,15 +18,15 @@ const(
 )
 
 type Place struct {
-	hours            [7]string
-	name             string
-	locationType     string
-	address          Address
-	formattedAddress string
-	location         [2]float64	// geolocation coordinates
-	id               string
-	priceLevel       int
-	rating			 float32
+	ID               string     `bson:"placeId"`
+	Name             string     `bson:"name"`
+	LocationType     string     `bson:"location_type"`
+	Address          Address    `bson:"address"`
+	FormattedAddress string     `bson:"formatted_address"`
+	Geolocation      [2]float64 `bson:"geolocation"` // geolocation coordinates
+	PriceLevel       int		`bson:"price_level"`
+	Rating           float32	`bson:"rating"`
+	Hours            [7]string  `bson:"hours"`
 }
 
 type Address struct{
@@ -40,19 +40,19 @@ type Address struct{
 }
 
 func (v *Place) GetName() string{
-	return v.name
+	return v.Name
 }
 
 func (v *Place) GetType() string{
-	return v.locationType
+	return v.LocationType
 }
 
 func (v *Place) GetHour(day Weekday) string {
-	return v.hours[day]
+	return v.Hours[day]
 }
 
 func (v *Place) GetID() string {
-	return v.id
+	return v.ID
 }
 
 //Sample Address in adr micro-format
@@ -61,63 +61,63 @@ func (v *Place) GetID() string {
 //San Francisco, CA 94107
 //U.S.A.
 func (v *Place) GetAddress() Address {
-	return v.address
+	return v.Address
 }
 
 func (v *Place) GetFormattedAddress() string{
-	return v.formattedAddress
+	return v.FormattedAddress
 }
 
 func (v *Place) GetLocation() [2]float64{
-	return v.location
+	return v.Geolocation
 }
 
 func (v *Place) GetPriceLevel() int{
-	return v.priceLevel
+	return v.PriceLevel
 }
 
 func (v *Place) GetRating() float32{
-	return v.rating
+	return v.Rating
 }
 
 // Set name if POI name changed
 func (v *Place) SetName(name string){
-	v.name = name
+	v.Name = name
 }
 
 // Set human-readable Address of this place
 func (v *Place) SetFormattedAddress(formattedAddress string){
-	v.formattedAddress = formattedAddress
+	v.FormattedAddress = formattedAddress
 }
 
 // Set type if POI type changed
 func (v *Place) SetType(t string){
-	v.locationType = t
+	v.LocationType = t
 }
 // Set time if POI opening hour changed for some day in a week
 func (v *Place) SetHour(day Weekday, hour string){
 	switch day {
 	case DATE_SUNDAY:
-		v.hours[day] = hour
+		v.Hours[day] = hour
 	case DATE_MONDAY:
-		v.hours[day] = hour
+		v.Hours[day] = hour
 	case DATE_TUESDAY:
-		v.hours[day] = hour
+		v.Hours[day] = hour
 	case DATE_WEDNESDAY:
-		v.hours[day] = hour
+		v.Hours[day] = hour
 	case DATE_THURSAY:
-		v.hours[day] = hour
+		v.Hours[day] = hour
 	case DATE_FRIDAY:
-		v.hours[day] = hour
+		v.Hours[day] = hour
 	case DATE_SATURDAY:
-		v.hours[day] = hour
+		v.Hours[day] = hour
 	default:
 		log.Fatalf("day specified (%d) is not in range of 0-6", day)
 	}
 }
 
 func (v *Place) SetID(id string){
-	v.id = id
+	v.ID = id
 }
 
 func (v *Place) SetAddress(addr string){
@@ -134,31 +134,31 @@ func (v *Place) SetAddress(addr string){
 		val := value[1:len(value)-1]
 		switch fieldName{
 		case `"post-office-box"`:
-			v.address.PObox = val
+			v.Address.PObox = val
 		case `"extended-address"`:
-			v.address.ExtendedAddr = val
+			v.Address.ExtendedAddr = val
 		case `"street-address"`:
-			v.address.StreetAddr = val
+			v.Address.StreetAddr = val
 		case `"locality"`:
-			v.address.Locality = val
+			v.Address.Locality = val
 		case `"region"`:
-			v.address.Region = val
+			v.Address.Region = val
 		case `"postal-code"`:
-			v.address.PostalCode = val
+			v.Address.PostalCode = val
 		case `"country-name"`:
-			v.address.Country = val
+			v.Address.Country = val
 		}
 	}
 }
 
 func (v *Place) SetLocation(location [2]float64){
-	v.location = location
+	v.Geolocation = location
 }
 
 func (v *Place) SetPriceLevel(priceRange int){
-	v.priceLevel = priceRange
+	v.PriceLevel = priceRange
 }
 
 func (v *Place) SetRating(rating float32){
-	v.rating = rating
+	v.Rating = rating
 }


### PR DESCRIPTION
MongoDB exploration is ongoing. Insert, find all working. Example code:


	client, _ := mongo.NewClient(options.Client().ApplyURI("mongodb://localhost:27017"))
	
	collection := client.Database("VacationPlanner").Collection("majorCities")
	
	// connect
	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
	err := client.Connect(ctx)
	if err != nil{
		log.Fatal(err)
	}
	
	Poi := POI.Place{"412341241", "Time Square", "Visit", POI.Address{},
		"Times Square, Manhattan, NY, USA", [2]float64{40.758896, -73.985130},
	1, 4.5, [7]string{}}
	
	InsertRes, _ := collection.InsertOne(ctx, Poi)
	
	fmt.Println(InsertRes.InsertedID)

To read the file

        var poi POI.Place
	filter := bson.M{"name": "Time Square"}

	err = collection.FindOne(ctx, filter).Decode(&poi)

	if err != nil {
		log.Fatal(err)
	}
	fmt.Println(poi)
