### PR TITLE
serve html as response for planning API

### DIFF
--- a/templates/plan_layout.html
+++ b/templates/plan_layout.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Vacation Plans</title>
+</head>
+<body>
+<h1>
+    Vacation Plans
+</h1>
+    {{range .Places}}
+        <table>
+            <tr>
+                <th> Start Time (Hour) </th>
+                <th> End Time (Hour) </th>
+                <th> Place Name </th>
+            </tr>
+
+            {{range .Places}}
+                <tr>
+                    <td> {{.StartTime}} </td>
+                    <td> {{.EndTime}} </td>
+                    <td> {{.PlaceName}} </td>
+                </tr>
+            {{end}}
+        </table>
+    {{end}}
+</body>
+</html>


### PR DESCRIPTION
serve html as response for planning API. The HTML displays a table for the travel plan.