### PR TITLE
fix 2d-sphere index missing issue when DB is dropped while server running

### DIFF
--- a/iowrappers/poi_searcher.go
+++ b/iowrappers/poi_searcher.go
@@ -61,7 +61,6 @@ func (poiSearcher *PoiSearcher) Geocode(query GeocodeQuery) (lat float64, lng fl
 // if client API key is invalid but not empty string, nearby search result will be empty
 func (poiSearcher *PoiSearcher) NearbySearch(request *PlaceSearchRequest) (places []POI.Place) {
 	dbHandler := poiSearcher.dbHandler
-	dbHandler.SetCollHandler(string(request.PlaceCat))
 
 	location := request.Location
 	cityCountry := strings.Split(location, ",")


### PR DESCRIPTION
This is an issue you could encounter while testing API. Best practice.

When testing with local database. Do not drop database while server is running. Make sure to first stop the server and then cleaning the data storage.