### PR TITLE
reduce stack printing level and reduce API user generated error level

### DIFF
--- a/planner/planner_API.go
+++ b/planner/planner_API.go
@@ -72,7 +72,7 @@ type PlanningPostRequest struct {
 // single-day, single-city planning method
 func (planner *MyPlanner) Planning(req *solution.PlanningRequest) (resp PlanningResponse) {
 	planningResp, err := planner.Solver.Solve(*req, planner.RedisLogger)
-	utils.CheckErrImmediate(err, utils.LogError)
+	utils.CheckErrImmediate(err, utils.LogInfo)
 	if err != nil {
 		resp.Err = err.Error()
 		resp.StatusCode = planningResp.Errcode
@@ -127,14 +127,14 @@ func (planner *MyPlanner) postPlanningApi(w http.ResponseWriter, r *http.Request
 
 	req := PlanningPostRequest{}
 	err := json.NewDecoder(r.Body).Decode(&req)
-	utils.CheckErrImmediate(err, utils.LogError)
+	utils.CheckErrImmediate(err, utils.LogInfo)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
 	planningReq, err := processPlanningPostRequest(&req)
-	utils.CheckErrImmediate(err, utils.LogError)
+	utils.CheckErrImmediate(err, utils.LogInfo)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		_ = json.NewEncoder(w).Encode(err.Error())

--- a/utils/err_handling.go
+++ b/utils/err_handling.go
@@ -45,9 +45,11 @@ func CheckErrImmediate(err error, level uint) {
 		default:
 			log.Error("No Level is provided for this error")
 		}
-		debug.PrintStack()
+		// print debug stack only if error level is higher than some threshold
+		if level < LogWarning {
+			debug.PrintStack()
+		}
 	}
-
 }
 
 func CheckErr(err Error) {


### PR DESCRIPTION
On API level, if error is generated by improper user input, we do not print stack.