### PR TITLE
Prevent creating new ext service clients each time API is hit

### DIFF
--- a/iowrappers/maps_client.go
+++ b/iowrappers/maps_client.go
@@ -7,7 +7,7 @@ import (
 )
 
 type SearchClient interface {
-	Create(apiKey string) error
+	Init(apiKey string) error
 }
 
 type MapsClient struct {
@@ -17,7 +17,7 @@ type MapsClient struct {
 }
 
 // create google maps client with api key
-func (c *MapsClient) Create(apiKey string) error {
+func (c *MapsClient) Init(apiKey string) error {
 	var err error
 	c.client, err = maps.NewClient(maps.WithAPIKey(apiKey))
 	if err != nil {

--- a/planner/redis_streams_logging.go
+++ b/planner/redis_streams_logging.go
@@ -10,5 +10,5 @@ func (planner MyPlanner) PlanningEventLogging(event PlanningEvent) {
 		"city":    event.City,
 		"country": event.Country,
 	}
-	planner.RedisLogger.StreamsLogging(planner.RedisStreamName, eventData)
+	planner.RedisClient.StreamsLogging(planner.RedisStreamName, eventData)
 }

--- a/solution/multi_slot_solution.go
+++ b/solution/multi_slot_solution.go
@@ -7,7 +7,6 @@ import (
 	"github.com/weihesdlegend/Vacation-planner/iowrappers"
 	"github.com/weihesdlegend/Vacation-planner/matching"
 	"github.com/weihesdlegend/Vacation-planner/utils"
-	"net/url"
 	"strconv"
 	"strings"
 )
@@ -31,12 +30,8 @@ const (
 	NoValidSolution              = 404
 )
 
-func (solver *Solver) Init(apiKey string, dbName string, dbUrl string, redisUrl *url.URL) {
+func (solver *Solver) Init(poiSearcher *iowrappers.PoiSearcher) {
 	solver.matcher = &matching.TimeMatcher{}
-	poiSearcher := &iowrappers.PoiSearcher{}
-	mapsClient := &iowrappers.MapsClient{}
-	utils.CheckErrImmediate(mapsClient.Create(apiKey), utils.LogFatal)
-	poiSearcher.Init(mapsClient, dbName, dbUrl, redisUrl)
 	solver.matcher.Init(poiSearcher)
 }
 


### PR DESCRIPTION
## Description
clearly describe changes in your PR, new feature or bug fixes

## Root Cause
Previously each time `solver.solve` is called, new service clients are created. Which both wastes time and thread resources.

## Solution description
Refactor `planner.init` such that only create one set of clients when planner is initiated. And use them throughout the life time of server up time.

## Covered E2E tests
Manually tested


## Final Checks
- [x] Have you removed commented code ?
- [x] Have you used gofmt to format your code ?
- [x] You are using approved terminology
- [ ] You have added unit tests
