### PR TITLE
Prevent caching slot solutions if no valid multi-slot solution is found

### DIFF
--- a/iowrappers/redis_client.go
+++ b/iowrappers/redis_client.go
@@ -25,6 +25,10 @@ type RedisClient struct {
 	client redis.Client
 }
 
+func (redisClient RedisClient) RemoveKeys(keys []string) {
+	redisClient.client.Del(keys...)
+}
+
 func (redisClient *RedisClient) Init(url *url.URL) {
 	password, _ := url.User.Password()
 	redisClient.client = *redis.NewClient(&redis.Options{
@@ -320,8 +324,8 @@ func (redisClient *RedisClient) CacheSlotSolution(req SlotSolutionCacheRequest, 
 	}
 }
 
-func (redisClient *RedisClient) GetSlotSolution(req SlotSolutionCacheRequest) (solution SlotSolutionCacheResponse, err error) {
-	redisKey := genSlotSolutionCacheKey(req)
+func (redisClient *RedisClient) GetSlotSolution(req SlotSolutionCacheRequest) (solution SlotSolutionCacheResponse, redisKey string, err error) {
+	redisKey = genSlotSolutionCacheKey(req)
 	json_, err := redisClient.client.Get(redisKey).Result()
 	if err != nil {
 		log.Errorf("get slot solution cache failure for request with key: %s", redisKey)

--- a/solution/generate_slot_solution.go
+++ b/solution/generate_slot_solution.go
@@ -59,7 +59,7 @@ func FindBestCandidates(candidates []SlotSolutionCandidate) []SlotSolutionCandid
 // Generate slot solution candidates
 // Parameter list matches slot request
 func GenerateSlotSolution(timeMatcher *matching.TimeMatcher, location string, evTag string, stayTimes []matching.TimeSlot,
-	radius uint, weekday POI.Weekday, redisClient iowrappers.RedisClient) (slotSolution SlotSolution) {
+	radius uint, weekday POI.Weekday, redisClient iowrappers.RedisClient) (slotSolution SlotSolution, slotSolutionRedisKey string) {
 	if len(stayTimes) != len(evTag) {
 		log.Fatal("User designated stay time does not match tag.")
 		return
@@ -85,7 +85,7 @@ func GenerateSlotSolution(timeMatcher *matching.TimeMatcher, location string, ev
 		Weekday:   weekday,
 	}
 
-	slotSolutionCacheResp, err := redisClient.GetSlotSolution(redisReq)
+	slotSolutionCacheResp, slotSolutionRedisKey, err := redisClient.GetSlotSolution(redisReq)
 	if err == nil { // cache hit
 		for _, candidate := range slotSolutionCacheResp.SlotSolutionCandidate {
 			slotSolutionCandidate := SlotSolutionCandidate{


### PR DESCRIPTION
## Description
Previously we invalidate multi-slot solution once per 24 hours. In production we found that sometimes the same link which gave result yesterday says `no solution found` on the next day. And since the result is cached. There is no way that users can get a different result for the next 24 hours. 

## Root Cause
Fundamentally the issue is caused by the uncertainty in priority-queue based solution finding process. There is a variation factor in the results generated by the selection process. Suppose we do not set an upper-bound on number of solutions in each slot solution, then this variation should be eliminated. However the tradeoff is the computational cost, which would cause delay that is unacceptable. 

## Solution description
Do not cache slot solutions for the case when no multi-slot solution can be found, so that when the same link is hit again. There is a chance that the randomness would generate a valid solution on a second try. third try, etc. Let's say guy A goes to the site and disappointed that no solution is found. However guy B went to the site and he still can see the solution. So on average the customer experience is decent.

## Covered E2E tests
manually tested. No solution case is verified


## Final Checks
- [x] Have you removed commented code ?
- [x] Have you used gofmt to format your code ?
