### PR TITLE
Feat/Add update place method in MongoDB operations

### DIFF
--- a/iowrappers/db_operations.go
+++ b/iowrappers/db_operations.go
@@ -205,9 +205,11 @@ func (dbHandler *DbHandler) InsertPlace(place POI.Place, placeCat POI.PlaceCateg
 	collHandler := dbHandler.handlers[collName]
 	err := collHandler.InsertPlace(place)
 	if err != nil {
-		log.Error(err)
 		if mgo.IsDup(err) {
-			log.Debugf("Duplicate insertion of %s to the database", place.Name)
+			log.Debugf("Database updating %s", place.Name)
+			_ = collHandler.UpdatePlace(place)
+		} else {
+			log.Error(err)
 		}
 	} else {
 		atomic.AddUint64(newDocCounter, 1)
@@ -236,6 +238,12 @@ func (collHandler *CollHandler) GetCollection() (coll *mgo.Collection) {
 
 func (collHandler *CollHandler) InsertPlace(place POI.Place) error {
 	err := collHandler.GetCollection().Insert(place)
+	return err
+}
+
+func (collHandler *CollHandler) UpdatePlace(place POI.Place) error {
+	query := bson.M{"_id": place.ID}
+	err := collHandler.GetCollection().Update(query, place)
 	return err
 }
 


### PR DESCRIPTION
## Description
Previously whenever a place is inserted, we check if the primary key (place ID) exists. If it exists, then the insertion is rejected. Realizing that if the data is updated, we miss the update. So if we update the document instead we can always get the new data saved in DB.

## Root Cause
As stated in description

## Solution description
Create `UpdatePlace` method in `CollHandler` and use the method in `DbHandler.InsertPlace`

## Covered E2E tests
Manually tested


## Final Checks
- [x] Have you removed commented code ?
- [x] Have you used gofmt to format your code ?
- [x] You are using approved terminology
