### PR TITLE
Feat/Allow return arbitrary number of planning results from GET API

### DIFF
--- a/solution/multi_slot_solution.go
+++ b/solution/multi_slot_solution.go
@@ -68,6 +68,12 @@ func (solver *Solver) Solve(req PlanningRequest, redisCli iowrappers.RedisClient
 			return
 		}
 	}
+
+	// set default number of planning results
+	if req.NumResults == 0 {
+		req.NumResults = NumSolutions
+	}
+
 	// each row contains candidates in one slot
 	candidates := make([][]SlotSolutionCandidate, len(req.SlotRequests))
 	for idx := range req.SlotRequests {
@@ -95,7 +101,7 @@ func (solver *Solver) Solve(req PlanningRequest, redisCli iowrappers.RedisClient
 		slotSolutionRedisKeys[idx] = slotSolutionRedisKey
 	}
 
-	resp.Solutions = genBestMultiSlotSolutions(candidates)
+	resp.Solutions = genBestMultiSlotSolutions(candidates, req.NumResults)
 	if len(resp.Solutions) == 0 {
 		invalidateSlotSolutionCache(&redisCli, slotSolutionRedisKeys)
 	}
@@ -130,7 +136,7 @@ func travelTime(fromLoc string, toLoc string, fromLocRadius uint, toLocRadius ui
 	return uint(distance / (TravelSpeed * 16.67)) // 16.67 is the ratio of m/minute and km/hour
 }
 
-func genBestMultiSlotSolutions(candidates [][]SlotSolutionCandidate) []MultiSlotSolution {
+func genBestMultiSlotSolutions(candidates [][]SlotSolutionCandidate, numResults uint64) []MultiSlotSolution {
 	res := make([]MultiSlotSolution, 0)
 	slotSolutionResults := make([][]SlotSolutionCandidate, 0)
 	path := make([]SlotSolutionCandidate, 0)
@@ -148,7 +154,7 @@ func genBestMultiSlotSolutions(candidates [][]SlotSolutionCandidate) []MultiSlot
 		}
 		res = append(res, multiSlotSolution)
 	}
-	bestSolutions := FindBestSolutions(res)
+	bestSolutions := FindBestSolutions(res, numResults)
 	for solutionIdx := range bestSolutions {
 		calTravelTime(&bestSolutions[solutionIdx])
 	}
@@ -234,6 +240,7 @@ type PlanningRequest struct {
 	SlotRequests []SlotRequest
 	SearchRadius uint
 	Weekday      POI.Weekday
+	NumResults   uint64
 }
 
 type SlotRequest struct {
@@ -249,7 +256,13 @@ type PlanningResponse struct {
 }
 
 // Find top multi-slot solutions
-func FindBestSolutions(candidates []MultiSlotSolution) []MultiSlotSolution {
+func FindBestSolutions(candidates []MultiSlotSolution, numResults uint64) []MultiSlotSolution {
+	res := make([]MultiSlotSolution, 0)
+
+	if numResults == 0 {
+		return res
+	}
+
 	m := make(map[string]MultiSlotSolution) // map for result extraction
 	vertexes := make([]graph.Vertex, len(candidates))
 	for idx, candidate := range candidates {
@@ -261,7 +274,7 @@ func FindBestSolutions(candidates []MultiSlotSolution) []MultiSlotSolution {
 	// use limited-size minimum priority queue
 	priorityQueue := &graph.MinPriorityQueueVertex{}
 	for _, vertex := range vertexes {
-		if priorityQueue.Len() == NumSolutions {
+		if priorityQueue.Len() == int(numResults) {
 			top := (*priorityQueue)[0]
 			if vertex.Key > top.Key {
 				heap.Pop(priorityQueue)
@@ -272,8 +285,6 @@ func FindBestSolutions(candidates []MultiSlotSolution) []MultiSlotSolution {
 		heap.Push(priorityQueue, vertex)
 	}
 
-	res := make([]MultiSlotSolution, 0)
-
 	for priorityQueue.Len() > 0 {
 		top := heap.Pop(priorityQueue).(graph.Vertex)
 		res = append(res, m[top.Name])
@@ -283,7 +294,7 @@ func FindBestSolutions(candidates []MultiSlotSolution) []MultiSlotSolution {
 }
 
 // Generate a standard request while we seek a better way to represent complex REST requests
-func GetStandardRequest(weekday POI.Weekday) (req PlanningRequest) {
+func GetStandardRequest(weekday POI.Weekday, numResults uint64) (req PlanningRequest) {
 	slot12 := matching.TimeSlot{Slot: POI.TimeInterval{Start: 9, End: 10}}
 	slot13 := matching.TimeSlot{Slot: POI.TimeInterval{Start: 10, End: 12}}
 	stayTimes1 := []matching.TimeSlot{slot12, slot13}
@@ -311,5 +322,6 @@ func GetStandardRequest(weekday POI.Weekday) (req PlanningRequest) {
 
 	req.SlotRequests = append(req.SlotRequests, []SlotRequest{slotReq1, slotReq2, slotReq3}...)
 	req.Weekday = weekday
+	req.NumResults = numResults
 	return
 }

--- a/test/find_best_solutions_test.go
+++ b/test/find_best_solutions_test.go
@@ -1,0 +1,48 @@
+package test
+
+import (
+	"github.com/weihesdlegend/Vacation-planner/solution"
+	"testing"
+)
+
+func TestFindBestSolutions(t *testing.T) {
+	solutionCandidates := make([]solution.MultiSlotSolution, 200)
+	for idx := range solutionCandidates {
+		solutionCandidates[idx] = solution.MultiSlotSolution{Score: float64(idx) + 1.0}
+	}
+
+	// test default
+	numResults := uint64(solution.NumSolutions)
+	bestSolutions := solution.FindBestSolutions(solutionCandidates, numResults)
+
+	if len(bestSolutions) != solution.NumSolutions {
+		t.Errorf("Expected number of solutions %d, got %d", solution.NumSolutions, len(bestSolutions))
+	}
+
+	// test regular case
+	expected := make(map[float64]bool)
+	for score := 200; score > 190; score-- {
+		expected[float64(score)] = true
+	}
+
+	numResults = uint64(10)
+	bestSolutions = solution.FindBestSolutions(solutionCandidates, numResults)
+
+	if len(bestSolutions) != 10 {
+		t.Errorf("Expected number of solutions %d, got %d", 10, len(bestSolutions))
+	}
+
+	for _, bestSolution := range bestSolutions {
+		if _, exist := expected[bestSolution.Score]; !exist {
+			t.Errorf("does not expect best solutions to contain solution with score %.2f", bestSolution.Score)
+		}
+	}
+
+	// test extreme
+	numResults = uint64(10000)
+	bestSolutions = solution.FindBestSolutions(solutionCandidates, numResults)
+
+	if len(bestSolutions) != 200 {
+		t.Errorf("Expected number of solutions %d, got %d", 200, len(bestSolutions))
+	}
+}

--- a/test/time_interval_sort_test.go
+++ b/test/time_interval_sort_test.go
@@ -25,7 +25,7 @@ func TestTimeIntervalSort(t *testing.T) {
 	sort.Sort(POI.ByStartTime(intervals))
 
 	for idx, interval := range intervals {
-		if idx < len(intervals) - 1 {
+		if idx < len(intervals)-1 {
 			if interval.Start > intervals[idx+1].Start {
 				t.Error("intervals are not sort correctly")
 			}


### PR DESCRIPTION
## Description
To allow pagination and return arbitrary number of planning results from GET API. We could add React page for user to navigate through the results. First we need capability to submit the `numberResults` as a parameter in the GET request.

## Solution description
- add parameter in GET API
- change function signatures in `solution` package to enable the functionality

## Covered E2E tests
unit test added and manually tested


## Final Checks
- [x] Have you removed commented code ?
- [x] Have you used gofmt to format your code ?
- [x] You are using approved terminology
- [x] You have added unit tests
