### PR TITLE
Fix micro format address input data when creating places

### DIFF
--- a/iowrappers/nearby_search.go
+++ b/iowrappers/nearby_search.go
@@ -211,7 +211,7 @@ func parsePlacesSearchResponse(resp maps.PlacesSearchResponse, locationType POI.
 		location := strings.Join([]string{lat, lng}, ",")
 		addr := ""
 		if microAddrMap != nil {
-			addr = microAddrMap[res.ID]
+			addr = microAddrMap[id]
 		}
 		priceLevel := res.PriceLevel
 		h := &POI.OpeningHours{}

--- a/test/create_visit_location_test.go
+++ b/test/create_visit_location_test.go
@@ -7,9 +7,14 @@ import (
 
 func TestCreatePlace(t *testing.T) {
 	location := "32.715736,-117.161087"
-	name := "lincoln park"
-	addr := "450 National Ave, Mountain View, USA, 94043"
-	place := POI.CreatePlace(name, location, addr, addr, "stay", nil, "lincolnpark_mtv", 3, 4.5)
+	name := "The Beat Museum"
+	addr := "540 Broadway, San Francisco, USA, 94113"
+	microAddr := `<span class="street-address">540 Broadway</span>,
+				<span class="locality">San Francisco</span>,
+				<span class="region">CA</span> <span class="postal-code">94133-4507</span>,
+				<span class="country-name">USA</span>`
+
+	place := POI.CreatePlace(name, location, microAddr, addr, "stay", nil, "lincolnpark_mtv", 3, 4.5)
 	if place.GetName() != name {
 		t.Errorf("Name setting is not correct. \n Expected: %s, got: %s",
 			name, place.GetName())
@@ -31,5 +36,18 @@ func TestCreatePlace(t *testing.T) {
 	if place.GetRating() != 4.5 {
 		t.Errorf("Price rating setting is not correct. \n Expected: %f \n Got: %f	",
 			4.5, place.GetRating())
+	}
+	retMicroAddr := place.GetAddress()
+	if retMicroAddr.StreetAddr != "540 Broadway" {
+		t.Errorf("micro address street address parsing error. \n Expected: 540 Broadway \n Got %s", retMicroAddr.StreetAddr)
+	}
+	if retMicroAddr.Country != "USA" {
+		t.Errorf("micro address country parsing error. \n Expected: USA \n Got %s", retMicroAddr.Country)
+	}
+	if retMicroAddr.Locality != "San Francisco" {
+		t.Errorf("micro address locality parsing error. \n Expected: San Francisco \n Got %s", retMicroAddr.Locality)
+	}
+	if retMicroAddr.PostalCode != "94133-4507" {
+		t.Errorf("micro address postal code parsing error. \n Expected: 94133-4507 \n Got %s", retMicroAddr.PostalCode)
 	}
 }


### PR DESCRIPTION
## Description
MongoDB place data micro format address has been missing for months, if not years. Finally found the culprit!

## Root Cause
Wrong ID passed into the `microAddress` map

## Solution description
Replace with correct ID key

## Covered E2E tests
Local test shows that the micro address data shows up in DB

