### PR TITLE
Feat/Implement async planning event persistence

### DIFF
--- a/iowrappers/db_operations.go
+++ b/iowrappers/db_operations.go
@@ -20,6 +20,7 @@ import (
 
 const (
 	UserCollection = "User"
+	PlanningEventsCollection = "PlanningEvents"
 )
 
 type DatabaseHandler interface {
@@ -46,12 +47,24 @@ type CollHandler struct {
 	collName string
 }
 
+type PlanningEvent struct {
+	User    string `json:"user"`
+	City    string `json:"city"`
+	Country string `json:"country"`
+	Timestamp string `json:"timestamp"`
+}
+
 func (dbHandler *DbHandler) Init(DbName string, url string) {
 	dbHandler.handlers = make(map[string]*CollHandler)
 	dbHandler.dbName = DbName
 	dbHandler.CreateSession(url)
 
 	dbHandler.SetCollHandler(UserCollection)
+	dbHandler.SetCollHandler(PlanningEventsCollection)
+}
+
+func (dbHandler DbHandler) CreatePlanningEvent(event PlanningEvent) {
+	_ = dbHandler.handlers[PlanningEventsCollection].GetCollection().Insert(event)
 }
 
 func (dbHandler *DbHandler) CreateSession(uri string) {

--- a/planner/post_api_helpers.go
+++ b/planner/post_api_helpers.go
@@ -167,4 +167,3 @@ func checkPostReqTimePlaceNum(req *PlanningPostRequest) (err error) {
 	}
 	return
 }
-


### PR DESCRIPTION
## Description
We need analytics of how users use our services. At the most basic level, we need to know the locations users search.

## Solution description
- Create a table in database to persist user search history, with fields `username, city, country, timestamp`
- Use go routines as workers to process planning events in API layer

## Covered E2E tests
Manually tested


## Final Checks
- [x] Have you removed commented code ?
- [x] Have you used gofmt to format your code ?
- [x] You are using approved terminology
