### PR TITLE
Store basic API statistics in Redis

### DIFF
--- a/planner/redis_streams_logging.go
+++ b/planner/redis_streams_logging.go
@@ -3,6 +3,7 @@ package planner
 import (
 	log "github.com/sirupsen/logrus"
 	"github.com/weihesdlegend/Vacation-planner/iowrappers"
+	"strings"
 	"sync"
 )
 
@@ -18,8 +19,8 @@ func (planner MyPlanner) PlanningEventLogging(event iowrappers.PlanningEvent) {
 
 func (planner MyPlanner) ProcessPlanningEvent(worker int, wg *sync.WaitGroup) {
 	for event := range planner.PlanningEvents {
-		log.Debugf("worker %d processing event %s", worker, event.City+" "+event.Country)
-		planner.LoginHandler.CreatePlanningEvent(event)
+		log.Debugf("worker %d processing event for %s", worker, strings.Title(event.City)+", "+strings.ToUpper(event.Country))
+		planner.RedisClient.CollectPlanningAPIStats(event)
 	}
 	wg.Done()
 }


### PR DESCRIPTION
## Description

- Remove the code that stores API usage events in Mongo
- Workers update Redis with API statistics

## Root Cause
Part 2 of removing Mongo dependency

## Covered E2E tests
Manually tested

