### PR TITLE
Refactor maps/Redis client to implement an interface

### DIFF
--- a/graph/update_places.go
+++ b/graph/update_places.go
@@ -36,7 +36,7 @@ func updatePlacesDetails(searcher *iowrappers.PoiSearcher, places []POI.Place) {
 		wg.Add(1)
 		go func(id string) {
 			defer wg.Done()
-			result, err := searcher.GetMapsClient().PlaceDetailedSearch(id)
+			result, err := iowrappers.PlaceDetailedSearch(searcher.GetMapsClient(), id)
 			if err != nil {
 				iowrappers.Logger.Error(err)
 				return

--- a/iowrappers/geocoding.go
+++ b/iowrappers/geocoding.go
@@ -8,14 +8,14 @@ import (
 )
 
 // Translate city, country to its central location
-func (c MapsClient) Geocode(query *GeocodeQuery) (lat float64, lng float64, err error) {
+func (mapsClient MapsClient) GetGeocode(query *GeocodeQuery) (lat float64, lng float64, err error) {
 	req := &maps.GeocodingRequest{
 		Components: map[maps.Component]string{
 			maps.ComponentLocality: query.City,
 			maps.ComponentCountry:  query.Country,
 		}}
 
-	resp, err := c.client.Geocode(context.Background(), req)
+	resp, err := mapsClient.client.Geocode(context.Background(), req)
 	if err != nil {
 		utils.CheckErrImmediate(err, utils.LogError)
 		return

--- a/iowrappers/maps_client.go
+++ b/iowrappers/maps_client.go
@@ -1,13 +1,19 @@
 package iowrappers
 
 import (
+	"errors"
+	"github.com/weihesdlegend/Vacation-planner/POI"
+	"github.com/weihesdlegend/Vacation-planner/utils"
 	"go.uber.org/zap"
 	"googlemaps.github.io/maps"
 	"os"
+	"reflect"
 )
 
+// abstraction of a client that performs location-based operations such as nearby search
 type SearchClient interface {
-	Init(apiKey string) error
+	GetGeocode(*GeocodeQuery) (float64, float64, error)    // translate a textual location to latitude and longitude
+	NearbySearch(*PlaceSearchRequest) ([]POI.Place, error) // search nearby places in a category around a central location
 }
 
 type MapsClient struct {
@@ -15,14 +21,17 @@ type MapsClient struct {
 	apiKey string
 }
 
-// create google maps client with api key
-func (c *MapsClient) Init(apiKey string) error {
-	var err error
-	c.client, err = maps.NewClient(maps.WithAPIKey(apiKey))
+// factory method for MapsClient
+func CreateMapsClient(apiKey string) MapsClient {
+	logErr(CreateLogger(), utils.LogError)
+	mapsClient, err := maps.NewClient(maps.WithAPIKey(apiKey))
 	if err != nil {
-		return err
+		Logger.Fatal(err)
 	}
-	return CreateLogger()
+	if reflect.ValueOf(mapsClient).IsNil() {
+		Logger.Fatal(errors.New("maps client does not exist"))
+	}
+	return MapsClient{client: mapsClient, apiKey: apiKey}
 }
 
 func CreateLogger() error {

--- a/iowrappers/nearby_search.go
+++ b/iowrappers/nearby_search.go
@@ -63,8 +63,10 @@ func (mapsClient *MapsClient) NearbySearch(request *PlaceSearchRequest) (places 
 	return
 }
 
-// ExtensiveNearbySearch tries to find a specified number of search results from a place category once for each location type in the category
-// maxRequestTime specifies the number of times to query for each location type having maxRequestTimes provides Google API call protection
+// ExtensiveNearbySearch tries to find a specified number of search results from
+// a place category once for each location type in the category maxRequestTime
+// specifies the number of times to query for each location type having
+// maxRequestTimes provides Google API call protection
 func (mapsClient *MapsClient) ExtensiveNearbySearch(maxRequestTimes uint, request *PlaceSearchRequest) (places []POI.Place, err error) {
 	if request.RankBy == "" {
 		request.RankBy = "prominence" // default rankBy value

--- a/iowrappers/nearby_search.go
+++ b/iowrappers/nearby_search.go
@@ -63,10 +63,8 @@ func (mapsClient *MapsClient) NearbySearch(request *PlaceSearchRequest) (places 
 	return
 }
 
-// ExtensiveNearbySearch tries to find a specified number of search results from
-// a place category once for each location type in the category maxRequestTime
-// specifies the number of times to query for each location type having
-// maxRequestTimes provides Google API call protection
+// ExtensiveNearbySearch attempts to find a specified number of places satisfy the request
+// within the maxRequestTime times of calling external APIs
 func (mapsClient *MapsClient) ExtensiveNearbySearch(maxRequestTimes uint, request *PlaceSearchRequest) (places []POI.Place, err error) {
 	if request.RankBy == "" {
 		request.RankBy = "prominence" // default rankBy value

--- a/iowrappers/poi_searcher.go
+++ b/iowrappers/poi_searcher.go
@@ -76,8 +76,7 @@ func (poiSearcher *PoiSearcher) NearbySearch(request *PlaceSearchRequest) (place
 	// request.Location is overwritten to lat,lng
 	request.Location = fmt.Sprint(lat) + "," + fmt.Sprint(lng)
 
-	//cachedPlaces := poiSearcher.redisClient.NearbySearch(request)
-	cachedPlaces := poiSearcher.redisClient.GetPlaces(request)
+	cachedPlaces, _ := poiSearcher.redisClient.NearbySearch(request)
 	Logger.Debugf("number of results from redis is %d", len(cachedPlaces))
 
 	lastSearchTime, cacheErr := poiSearcher.redisClient.GetMapsLastSearchTime(location, request.PlaceCat)

--- a/planner/planner_API.go
+++ b/planner/planner_API.go
@@ -79,7 +79,7 @@ type PlanningPostRequest struct {
 
 func (planner *MyPlanner) Init(mapsClientApiKey string, redisURL *url.URL, redisStreamName string) {
 	planner.PlanningEvents = make(chan iowrappers.PlanningEvent, jobQueueBufferSize)
-	planner.RedisClient.Init(redisURL)
+	planner.RedisClient = iowrappers.CreateRedisClient(redisURL)
 	planner.RedisStreamName = redisStreamName
 	if redisStreamName == "" {
 		planner.RedisStreamName = "stream:planning_api_usage"

--- a/solution/multi_slot_solution.go
+++ b/solution/multi_slot_solution.go
@@ -45,7 +45,7 @@ func (solver *Solver) ValidateLocation(slotRequestLocation *string) bool {
 		City:    countryCity[0],
 		Country: countryCity[1],
 	}
-	_, _, err := solver.matcher.PoiSearcher.Geocode(&geoQuery)
+	_, _, err := solver.matcher.PoiSearcher.GetGeocode(&geoQuery)
 	if err != nil {
 		return false
 	}

--- a/test/redis_client_mocks/geocoding_cache_test.go
+++ b/test/redis_client_mocks/geocoding_cache_test.go
@@ -18,9 +18,9 @@ func TestGeoCodingCache(t *testing.T) {
 
 	RedisClient.SetGeocode(geoCodeQuery, expectedLat, expectedLng, geoCodeQuery)
 
-	lat, lng, exist := RedisClient.GetGeocode(&geoCodeQuery)
+	lat, lng, geocodeMissingErr := RedisClient.GetGeocode(&geoCodeQuery)
 
-	if !exist || lat != expectedLat || lng != expectedLng {
+	if geocodeMissingErr != nil || lat != expectedLat || lng != expectedLng {
 		t.Errorf("geo-coding for %s fails",
 			strings.Join([]string{geoCodeQuery.City, geoCodeQuery.Country}, ","))
 	}

--- a/test/redis_client_mocks/get_places_geo_cmd_test.go
+++ b/test/redis_client_mocks/get_places_geo_cmd_test.go
@@ -66,7 +66,7 @@ func TestGetPlaces(t *testing.T) {
 		MinNumResults: 1,
 	}
 
-	cachedVisitPlaces := RedisClient.GetPlaces(&placeSearchRequest)
+	cachedVisitPlaces, _ := RedisClient.NearbySearch(&placeSearchRequest)
 
 	if len(cachedVisitPlaces) != 1 || cachedVisitPlaces[0].ID != places[0].ID {
 		t.Logf("number of nearby visit places obtained from Redis is %d", len(cachedVisitPlaces))
@@ -82,7 +82,7 @@ func TestGetPlaces(t *testing.T) {
 		MinNumResults: 2,
 	}
 
-	cachedEateryPlaces := RedisClient.GetPlaces(&placeSearchRequest)
+	cachedEateryPlaces, _ := RedisClient.NearbySearch(&placeSearchRequest)
 
 	if len(cachedEateryPlaces) != 1 || cachedEateryPlaces[0].ID != places[2].ID {
 		t.Logf("number of nearby eatery places obtained from Redis is %d", len(cachedEateryPlaces))
@@ -90,7 +90,7 @@ func TestGetPlaces(t *testing.T) {
 	}
 
 	// expect to return empty slice if total number of cached places in a category is less than requested minimum
-	cachedVisitPlaces = RedisClient.GetPlaces(&iowrappers.PlaceSearchRequest{MinNumResults: 2, PlaceCat: "Visit"})
+	cachedVisitPlaces, _ = RedisClient.NearbySearch(&iowrappers.PlaceSearchRequest{MinNumResults: 2, PlaceCat: "Visit"})
 	if len(cachedVisitPlaces) != 0 {
 		t.Error("should return empty slice if total number of cached places in a category is less than requested minimum")
 	}

--- a/test/redis_client_mocks/helpers.go
+++ b/test/redis_client_mocks/helpers.go
@@ -15,5 +15,5 @@ func init() {
 
 	redisUrl := "redis://" + RedisMockSvr.Addr()
 	redisURL, _ := url.Parse(redisUrl)
-	RedisClient.Init(redisURL)
+	RedisClient = iowrappers.CreateRedisClient(redisURL)
 }

--- a/test/redis_client_mocks/nearby_search_test.go
+++ b/test/redis_client_mocks/nearby_search_test.go
@@ -50,7 +50,8 @@ func TestNearbySearch(t *testing.T) {
 		Radius:   uint(2511),
 	}
 
-	cachedPlaces, err := RedisClient.NearbySearch(&placeSearchRequest)
+	var cachedPlaces []POI.Place
+	cachedPlaces, err = RedisClient.NearbySearchNotUsed(&placeSearchRequest)
 
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
## Description/Overview
Io-wrappers package has 2 important types, `MapsClient` and `RedisClient`, responsible for external communications between our server and external API / Redis server. And their core functionalities of providing geo-location based searching functions are quite similar. Thus it makes sense to refactor and consolidate both under an interface `SearchClient`.

## Solution description
Re-define the `SearchClient` interface
Refactor factory methods for `MapsClient` and `RedisClient`
Refactor some `MapsClient` methods to none-type dependent functions

## Covered E2E tests
manually tested


## Final Checks
- [x] Have you removed commented code ?
- [x] Have you used gofmt to format your code ?
- [x] You are using approved terminology
- [ ] You have added unit tests
