### PR TITLE
Fix Redis place update issue

### DIFF
--- a/graph/time_cluster.go
+++ b/graph/time_cluster.go
@@ -86,7 +86,7 @@ func (placeManager *TimeClustersManager) PlaceSearch(location string, searchRadi
 	}
 	request.MaxNumResults = 2 * request.MinNumResults
 	placeManager.places, _ = placeManager.poiSearcher.NearbySearch(&request)
-	updatePlacesDetails(placeManager.poiSearcher, placeManager.places)
+	placeManager.poiSearcher.UpdateRedis(UpdatePlacesDetails(placeManager.poiSearcher, placeManager.places))
 }
 
 // assign Places to time Clusters using their time interval info

--- a/graph/update_places.go
+++ b/graph/update_places.go
@@ -19,7 +19,7 @@ func detailsResultMap() *PlaceDetailsResultMap {
 
 func placeNeedUpdate(place *POI.Place) bool {
 	if len(strings.TrimSpace(place.GetURL())) == 0 || place.GetURL() == iowrappers.GoogleSearchHomePageURL {
-		logrus.Debugf("place with ID: %s need URL update", place.GetID())
+		logrus.Debugf("[REDIS URL UPDATE] place with ID: %s needs URL update", place.GetID())
 		return true
 	}
 	return false
@@ -64,5 +64,5 @@ func UpdatePlacesDetails(searcher iowrappers.SearchClient, places []POI.Place) (
 
 func updatePlaceDetails(place *POI.Place, details POI.Place) {
 	place.SetURL(details.GetURL())
-	logrus.Debugf("place with ID: %s URL updated to %s", place.GetID(), place.GetURL())
+	logrus.Debugf("[REDIS URL UPDATE] the URL of place with ID: %s has been updated to %s", place.GetID(), place.GetURL())
 }

--- a/graph/update_places.go
+++ b/graph/update_places.go
@@ -1,28 +1,33 @@
 package graph
 
 import (
+	"github.com/sirupsen/logrus"
 	"github.com/weihesdlegend/Vacation-planner/POI"
 	"github.com/weihesdlegend/Vacation-planner/iowrappers"
-	"googlemaps.github.io/maps"
 	"strings"
 	"sync"
 )
 
 type PlaceDetailsResultMap struct {
 	sync.Mutex
-	results map[string]maps.PlaceDetailsResult
+	results map[string]POI.Place
 }
 
-func newPlaceDetailsResultMap() *PlaceDetailsResultMap {
-	return &PlaceDetailsResultMap{results: map[string]maps.PlaceDetailsResult{}}
+func detailsResultMap() *PlaceDetailsResultMap {
+	return &PlaceDetailsResultMap{results: map[string]POI.Place{}}
 }
 
 func placeNeedUpdate(place *POI.Place) bool {
-	return len(strings.TrimSpace(place.GetURL())) == 0 || place.GetURL() == iowrappers.GoogleSearchHomePageURL
+	if len(strings.TrimSpace(place.GetURL())) == 0 || place.GetURL() == iowrappers.GoogleSearchHomePageURL {
+		logrus.Debugf("place with ID: %s need URL update", place.GetID())
+		return true
+	}
+	return false
 }
 
-func updatePlacesDetails(searcher *iowrappers.PoiSearcher, places []POI.Place) {
-	m := newPlaceDetailsResultMap()
+// use this function as a migration method as more fields are added to the POI.Place data model
+func UpdatePlacesDetails(searcher iowrappers.SearchClient, places []POI.Place) (placesNeedUpdate []POI.Place) {
+	m := detailsResultMap()
 	// for filter places need update and look up in places
 	placeIdToIdx := make(map[string]int)
 	for idx, place := range places {
@@ -31,12 +36,14 @@ func updatePlacesDetails(searcher *iowrappers.PoiSearcher, places []POI.Place) {
 		}
 	}
 
+	placesNeedUpdate = make([]POI.Place, 0)
 	wg := sync.WaitGroup{}
 	for placeId := range placeIdToIdx {
 		wg.Add(1)
+		placeId := placeId
 		go func(id string) {
 			defer wg.Done()
-			result, err := iowrappers.PlaceDetailedSearch(searcher.GetMapsClient(), id)
+			result, err := searcher.PlaceDetailsSearch(placeId)
 			if err != nil {
 				iowrappers.Logger.Error(err)
 				return
@@ -50,9 +57,12 @@ func updatePlacesDetails(searcher *iowrappers.PoiSearcher, places []POI.Place) {
 
 	for placeId, idx := range placeIdToIdx {
 		updatePlaceDetails(&places[idx], m.results[placeId])
+		placesNeedUpdate = append(placesNeedUpdate, places[idx])
 	}
+	return placesNeedUpdate
 }
 
-func updatePlaceDetails(place *POI.Place, details maps.PlaceDetailsResult) {
-	place.URL = details.URL
+func updatePlaceDetails(place *POI.Place, details POI.Place) {
+	place.SetURL(details.GetURL())
+	logrus.Debugf("place with ID: %s URL updated to %s", place.GetID(), place.GetURL())
 }

--- a/iowrappers/maps_client.go
+++ b/iowrappers/maps_client.go
@@ -14,6 +14,7 @@ import (
 type SearchClient interface {
 	GetGeocode(*GeocodeQuery) (float64, float64, error)    // translate a textual location to latitude and longitude
 	NearbySearch(*PlaceSearchRequest) ([]POI.Place, error) // search nearby places in a category around a central location
+	PlaceDetailsSearch(placeId string) (place POI.Place, err error)
 }
 
 type MapsClient struct {

--- a/iowrappers/nearby_search.go
+++ b/iowrappers/nearby_search.go
@@ -63,6 +63,10 @@ func (mapsClient *MapsClient) NearbySearch(request *PlaceSearchRequest) (places 
 	return
 }
 
+func (mapsClient *MapsClient) PlaceDetailsSearch(string) (place POI.Place, err error) {
+	return
+}
+
 // ExtensiveNearbySearch attempts to find a specified number of places satisfy the request
 // within the maxRequestTime times of calling external APIs
 func (mapsClient *MapsClient) ExtensiveNearbySearch(maxRequestTimes uint, request *PlaceSearchRequest) (places []POI.Place, err error) {

--- a/iowrappers/poi_searcher.go
+++ b/iowrappers/poi_searcher.go
@@ -5,6 +5,7 @@ import (
 	"github.com/weihesdlegend/Vacation-planner/POI"
 	"github.com/weihesdlegend/Vacation-planner/utils"
 	"go.uber.org/zap"
+	"googlemaps.github.io/maps"
 	"net/url"
 	"strings"
 	"time"
@@ -127,6 +128,17 @@ func (poiSearcher *PoiSearcher) NearbySearch(request *PlaceSearchRequest) (place
 			request.Location, request.Radius, request.PlaceCat)
 		Logger.Debug("location may be invalid")
 	}
+	return
+}
+
+func (poiSearcher *PoiSearcher) PlaceDetailsSearch(placeId string) (place POI.Place, err error) {
+	var res maps.PlaceDetailsResult
+	res, err = PlaceDetailedSearch(&poiSearcher.mapsClient, placeId)
+	if err != nil {
+		return
+	}
+	// for now only updates the URL field
+	place.SetURL(res.URL)
 	return
 }
 

--- a/test/redis_client_mocks/nearby_search_test.go
+++ b/test/redis_client_mocks/nearby_search_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestNearbySearch(t *testing.T) {
+func TestNearbySearchNotUsed(t *testing.T) {
 	places := make([]POI.Place, 2)
 	places[0] = POI.Place{
 		ID:               "1001",

--- a/test/update_places_details_test.go
+++ b/test/update_places_details_test.go
@@ -1,0 +1,43 @@
+package test
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/weihesdlegend/Vacation-planner/POI"
+	"github.com/weihesdlegend/Vacation-planner/graph"
+	"github.com/weihesdlegend/Vacation-planner/iowrappers"
+	"testing"
+)
+
+const MockURL = "www.maps.google.com/my-favorite"
+
+type SearchClientMock struct {
+}
+
+func (mocker SearchClientMock) GetGeocode(*iowrappers.GeocodeQuery) (float64, float64, error) {
+	return 0.0, 0.0, nil
+}
+
+func (mocker SearchClientMock) NearbySearch(*iowrappers.PlaceSearchRequest) ([]POI.Place, error) {
+	return nil, nil
+}
+
+func (mocker SearchClientMock) PlaceDetailsSearch(string) (place POI.Place, err error) {
+	place.URL = MockURL
+	return
+}
+
+func TestUpdatePlaceDetails(t *testing.T) {
+	searcher := SearchClientMock{}
+
+	places := make([]POI.Place, 1)
+	places[0] = POI.Place{URL: ""}
+	assert.True(t, places[0].GetURL()=="")
+
+	placesNeedUpdate := graph.UpdatePlacesDetails(searcher, places)
+	if len(placesNeedUpdate) != 1 {
+		t.Fatalf("expected number of places need update to be 1, got %d", len(placesNeedUpdate))
+	}
+	if placesNeedUpdate[0].GetURL() != MockURL {
+		t.Errorf("expected updated URL to be %s, got %s", MockURL, placesNeedUpdate[0].GetURL())
+	}
+}


### PR DESCRIPTION
## Description
For the places without URL after update places with new detailed search, Redis is not updating. 

## Root Cause
Production server makes way too many place details search calls

## Solution

- Make `updatePlacesDetails` method returns a list of places and update Redis. 
- Fixed issues in the Redis update method.

## Testing
Integration test procedure
- Obtain places without URL by removing URL field in the field mask
- Remove slot solutions to force the call flow to the lower-level place search
- Since search timer is not up, it forces the call flow to call the `updatePlaceDetails` function
- Check if the same place get updated URL


## Final Checks
- [x] Have you removed commented code ?
- [x] Have you used gofmt to format your code ?
- [x] You have added unit tests
