### PR TITLE
Get Google Maps detail search fields from config file

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Build
       run: go build -v .
-      working-directory: ./main
+      working-directory: .
 
     - name: Test
       run: go test -v ./...

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bin/main
+web: bin/Vacation-planner

--- a/config/config.yml
+++ b/config/config.yml
@@ -1,0 +1,8 @@
+server:
+  google_maps:
+    detailed_search_fields:
+      - name
+      - opening_hours
+      - formatted_address
+      - url
+      - user_ratings_total

--- a/go.mod
+++ b/go.mod
@@ -25,4 +25,5 @@ require (
 	gonum.org/v1/gonum v0.0.0-20190808205415-ced62fe5104b
 	google.golang.org/protobuf v1.25.0 // indirect
 	googlemaps.github.io/maps v1.2.3
+	gopkg.in/yaml.v2 v2.3.0
 )

--- a/iowrappers/maps_client.go
+++ b/iowrappers/maps_client.go
@@ -19,8 +19,14 @@ type SearchClient interface {
 }
 
 type MapsClient struct {
-	client *maps.Client
-	apiKey string
+	client               *maps.Client
+	apiKey               string
+	DetailedSearchFields []string
+}
+
+func (mapsClient *MapsClient) SetDetailedSearchFields(fields []string) {
+	mapsClient.DetailedSearchFields = fields
+	Logger.Debugf("Set DetailedSearchFields: %v", mapsClient.DetailedSearchFields)
 }
 
 // factory method for MapsClient

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"github.com/kelseyhightower/envconfig"
 	log "github.com/sirupsen/logrus"
 	"github.com/weihesdlegend/Vacation-planner/planner"
+	"gopkg.in/yaml.v2"
 	"net/url"
 	"os"
 	"os/signal"
@@ -24,6 +25,14 @@ type Config struct {
 	MapsClientApiKey string `required:"true" split_words:"true"`
 }
 
+type Configurations struct {
+	Server struct{
+		GoogleMaps struct{
+			DetailedSearchFields []string `yaml:"detailed_search_fields"`
+		} `yaml:"google_maps"`
+	} `yaml:"server"`
+}
+
 func RunServer() {
 	conf := Config{}
 	err := envconfig.Process("", &conf)
@@ -34,6 +43,17 @@ func RunServer() {
 	redisURL, err := url.Parse(conf.Redis.RedisUrl)
 	if err != nil {
 		log.Fatal(err)
+	}
+
+	configFile, configFileReadErr := os.Open("config/config.yml")
+	if configFileReadErr != nil {
+		log.Fatalf("config read failure: %v", configFileReadErr)
+	}
+
+	config := &Configurations{}
+	configFileDecoder := yaml.NewDecoder(configFile)
+	if configFileDecodeErr := configFileDecoder.Decode(config); configFileDecodeErr != nil {
+		log.Fatal(configFileDecodeErr)
 	}
 
 	myPlanner := planner.MyPlanner{}

--- a/solution/multi_slot_solution.go
+++ b/solution/multi_slot_solution.go
@@ -21,7 +21,7 @@ const (
 
 // Solvers are used by planners to solve the planning problem
 type Solver struct {
-	matcher *matching.TimeMatcher
+	Matcher *matching.TimeMatcher
 }
 
 // mapping from status to standard http status codes
@@ -36,8 +36,8 @@ const (
 )
 
 func (solver *Solver) Init(poiSearcher *iowrappers.PoiSearcher) {
-	solver.matcher = &matching.TimeMatcher{}
-	solver.matcher.Init(poiSearcher)
+	solver.Matcher = &matching.TimeMatcher{}
+	solver.Matcher.Init(poiSearcher)
 }
 
 func (solver *Solver) ValidateLocation(context context.Context, slotRequestLocation *string) bool {
@@ -46,7 +46,7 @@ func (solver *Solver) ValidateLocation(context context.Context, slotRequestLocat
 		City:    countryCity[0],
 		Country: countryCity[1],
 	}
-	_, _, err := solver.matcher.PoiSearcher.GetGeocode(context, &geoQuery)
+	_, _, err := solver.Matcher.PoiSearcher.GetGeocode(context, &geoQuery)
 	if err != nil {
 		return false
 	}
@@ -84,7 +84,7 @@ func (solver *Solver) Solve(context context.Context, redisCli iowrappers.RedisCl
 		return
 	}
 
-	// validate location with poiSearcher of the time matcher
+	// validate location with PoiSearcher of the TimeMatcher
 	for idx := range req.SlotRequests {
 		if !solver.ValidateLocation(context, &req.SlotRequests[idx].Location) {
 			resp.Err = errors.New("invalid travel destination")
@@ -134,7 +134,7 @@ func (solver *Solver) Solve(context context.Context, redisCli iowrappers.RedisCl
 			continue
 		}
 		location, evTag, stayTimes := slotRequest.Location, slotRequest.EvOption, slotRequest.StayTimes
-		slotSolution, slotSolutionRedisKey, err := GenerateSlotSolution(context, solver.matcher, location, evTag, stayTimes, req.SearchRadius, req.Weekday, redisCli, redisRequests[idx])
+		slotSolution, slotSolutionRedisKey, err := GenerateSlotSolution(context, solver.Matcher, location, evTag, stayTimes, req.SearchRadius, req.Weekday, redisCli, redisRequests[idx])
 		// The candidates in each slot should satisfy the travel time constraints and inter-slot constraint
 		if err != nil {
 			if err.Error() == ReqTimeSlotsTagMismatchErrMsg {


### PR DESCRIPTION
## Description
As a first step for developing data migration endpoint, we need a tiny database for available fields from Google Maps details search. Use config file to convey this information.

## Solution
Define config structure in `config.yml` and load the data with `gopkg.in/yaml` package.

## Testing
performed manual integration tests

