### PR TITLE
Fix: Search page receives cookies and verifies them

### DIFF
--- a/planner/planner_API.go
+++ b/planner/planner_API.go
@@ -281,8 +281,12 @@ func (planner *MyPlanner) Planning(ctx context.Context, planningRequest *solutio
 }
 
 // API definitions
-func (planner *MyPlanner) indexPageHandler(c *gin.Context) {
-	c.HTML(http.StatusOK, "index.html", gin.H{})
+func (planner *MyPlanner) searchPageHandler(c *gin.Context) {
+	c.HTML(http.StatusOK, "search_page.html", gin.H{})
+}
+
+func (planner *MyPlanner) homePageHandler(c *gin.Context){
+	c.Redirect(http.StatusMovedPermanently, "/v1/")
 }
 
 // HTTP POST API end-point
@@ -409,10 +413,11 @@ func (planner MyPlanner) SetupRouter(serverPort string) *http.Server {
 	// TODO: change to front-end domain once front-end server is deployed
 	myRouter.Use(cors.Default())
 
-	myRouter.GET("", planner.indexPageHandler)
+	myRouter.GET("/", planner.homePageHandler)
 
 	v1 := myRouter.Group("/v1")
 	{
+		v1.GET("/", planner.searchPageHandler)
 		v1.GET("/plans", planner.getPlanningApi)
 		//v1.POST("/plans", planner.postPlanningApi)
 		v1.POST("/signup", planner.UserSignup)

--- a/templates/login_page.html
+++ b/templates/login_page.html
@@ -77,7 +77,7 @@
                 XHR.onload = function () {
                     if (XHR.readyState === XHR.DONE) {
                         if (XHR.status === 200) {
-                            window.location = "/?username=" + username;
+                            window.location = "/";
                         } else if (XHR.status === 401) {
                             alert("login failed, please check your credentials");
                         }

--- a/templates/search_page.html
+++ b/templates/search_page.html
@@ -8,6 +8,8 @@
     <!-- Bootstrap CSS -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css"
         integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+    <script src="https://cdn.jsdelivr.net/npm/js-cookie@rc/dist/js.cookie.min.js"></script>
+
     <title>vacation planner</title>
 </head>
 
@@ -85,17 +87,27 @@
         crossorigin="anonymous"></script>
     <script>
         function updateUsername() {
-            const query = window.location.search;
+            const username = Cookies.get('Username');
+            if (username) {
+                console.log(`username is ${username}`);
+            } else {
+                console.log("user is not logged in.");
+            }
 
-            const urlParams = new URLSearchParams(query);
+            const jwtToken = Cookies.get("JWT");
+            // if JWT is present then the session is still valid, otherwise JWT token will be removed
+            if (jwtToken) {
+                console.log(`JWT token ${jwtToken}`);
+            } else {
+                console.log("log in expired.");
+            }
 
-            const userName = urlParams.get("username");
-            if (userName != null) {
+            if (username && jwtToken) {
                 document.getElementById("login").style.display = "none";
                 document.getElementById("signup").style.display = "none";
 
                 const userNameElement = document.getElementById("username");
-                userNameElement.innerText = userName;
+                userNameElement.innerText = username;
             }
         }
 


### PR DESCRIPTION
## Description
Currently after logged-in user goes to search page, the username is lost. This is confusing since users would not know if they logged in or not.

## Root Cause
Previous implementation has flaws. Cookies are only available on /v1 path endpoints.

## Solution
- Redirect home page request to /v1
- Search page verifies JWT token and use username from cookies to render
- Added JS-cookie library can be used for logging out users as well


## Final Checks
- [x] Have you removed commented code ?
- [x] Have you used gofmt to format your code ?
- [ x] You have added unit tests
