### PR TITLE
Move search icon inside address search area

### DIFF
--- a/templates/search_page.html
+++ b/templates/search_page.html
@@ -49,11 +49,13 @@
 
     <div class="row">
         <form class="d-flex" action="/v1/plans" method="get">
-            <div class="input-group">
+            <div class="input-group w-auto">
                 <input class="form-control-sm border border-secondary" type="date" id="datepicker" name="date"
                        value="2020-02-29">
-
-                <input class="form-control border border-secondary" type="search" id="location" placeholder="Search"
+            </div>
+            <div class="input-group border border-secondary rounded-1">
+                <i id="searchIcon" class="input-group-text border-0 bi bi-search bg-white"></i>
+                <input class="form-control border-0" type="search" id="location" placeholder="Search"
                        aria-label="Search"
                        name="location" value="Los Angeles, USA" list="datalistOptions">
 
@@ -65,12 +67,6 @@
                     <option value="New York City, USA">
                     <option value="Beijing, China">
                 </datalist>
-
-                <button id="searchButton" class="btn" type="submit">
-                    <i id="searchIcon" class="bi bi-search visible"></i>
-                    <span id="searchSpinner" class="spinner-border text-info spinner-border-sm visually-hidden"
-                          role="status" aria-hidden="true"></span>
-                </button>
             </div>
 
         </form>


### PR DESCRIPTION
## Description
Move search icon inside the address search box on the search page

## Root Cause
N/A

## Solution
Update search_page.html; Create a parent div for search icon and the address input element.

## Testing
Did you add any new test for this change, performed manual integration tests, or both?
Tested new appearance of search page locally, and manually tested the trip search feature

## Final Checks
- [ ] Have you removed commented code ?
- [ ] Have you used gofmt to format your code ?
- [ ] You have added unit tests
