### PR TITLE
Bug fix of missing date display in search page after clicking autofill

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -32,6 +32,7 @@ function locateMe() {
         const today = new Date();
 
         console.log(latitude, longitude);
+        console.log(today);
 
         const url = "/v1/reverse-geocoding"
         await axios.get(url, {
@@ -47,7 +48,11 @@ function locateMe() {
                     if (month < 10) {
                         month = "0" + month.toString();
                     }
-                    document.getElementById("datepicker").value = [today.getFullYear(), month, today.getDate()].join("-");
+                    let day = today.getDate(); 
+                    if (day < 10) { 
+                        day = "0" + day.toString();
+                    }
+                    document.getElementById("datepicker").value = [today.getFullYear(), month, day].join("-");
                 }
             ).catch(
                 err => console.error(err)


### PR DESCRIPTION
## Description
Discover that the main search page is missing date display after clicking autofill button.

## Root Cause
The date value needs comply with the format yyyy-mm-dd for the date input. For certain dates such as 10/01/2021, the day value can be a single digit (1) which violates the requirement.

## Solution
Prepend a "0" to day, if day is less than 10.

## Testing
Did you add any new test for this change, performed manual integration tests, or both?
Manual integration tests locally for functionalities including autofill, trip result searching etc.

## Final Checks
- [ ] Have you removed commented code ?
- [ ] Have you used gofmt to format your code ?
- [ ] You have added unit tests
