### PR TITLE
Fix: Set only JWT in session cookies

### DIFF
--- a/assets/js/jwt-decode.js
+++ b/assets/js/jwt-decode.js
@@ -1,0 +1,116 @@
+/**
+ * The code was extracted from and modified based on:
+ * https://github.com/auth0/jwt-decode/blob/222db61fbaeea8ffd412a306039fea769ce43093/build/jwt-decode.js
+ */
+const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+
+function InvalidCharacterError(message) {
+    this.message = message;
+}
+
+InvalidCharacterError.prototype = new Error();
+InvalidCharacterError.prototype.name = "InvalidCharacterError";
+
+function polyfill(input) {
+    const str = String(input).replace(/=+$/, "");
+    if (str.length % 4 === 1) {
+        throw new InvalidCharacterError(
+            "'atob' failed: The string to be decoded is not correctly encoded."
+        );
+    }
+    for (
+        // initialize result and counters
+        let bc = 0, bs, buffer, idx = 0, output = "";
+        // get next character
+        (buffer = str.charAt(idx++));
+        // character found in table? initialize bit storage and add its ascii value;
+        ~buffer &&
+        ((bs = bc % 4 ? bs * 64 + buffer : buffer),
+            // and if not first of each 4 characters,
+            // convert the first 8 bits to one ascii character
+        bc++ % 4) ?
+            (output += String.fromCharCode(255 & (bs >> ((-2 * bc) & 6)))) :
+            0
+    ) {
+        // try to find character in table (0-63, not found => -1)
+        buffer = chars.indexOf(buffer);
+    }
+    return output;
+}
+
+var atob = (typeof window !== "undefined" &&
+        window.atob &&
+        window.atob.bind(window)) ||
+    polyfill;
+
+function b64DecodeUnicode(str) {
+    return decodeURIComponent(
+        atob(str).replace(/(.)/g, function (m, p) {
+            var code = p.charCodeAt(0).toString(16).toUpperCase();
+            if (code.length < 2) {
+                code = "0" + code;
+            }
+            return "%" + code;
+        })
+    );
+}
+
+function base64_url_decode(str) {
+    let output = str.replace(/-/g, "+").replace(/_/g, "/");
+    switch (output.length % 4) {
+        case 0:
+            break;
+        case 2:
+            output += "==";
+            break;
+        case 3:
+            output += "=";
+            break;
+        default:
+            throw "Illegal base64url string!";
+    }
+
+    try {
+        return b64DecodeUnicode(output);
+    } catch (err) {
+        return atob(output);
+    }
+}
+
+function InvalidTokenError(message) {
+    this.message = message;
+}
+
+InvalidTokenError.prototype = new Error();
+InvalidTokenError.prototype.name = "InvalidTokenError";
+
+function jwtDecode(token, options) {
+    if (typeof token !== "string") {
+        throw new InvalidTokenError("Invalid token specified");
+    }
+
+    options = options || {};
+    const pos = options.header === true ? 0 : 1;
+    try {
+        return JSON.parse(base64_url_decode(token.split(".")[pos]));
+    } catch (e) {
+        throw new InvalidTokenError("Invalid token specified: " + e.message);
+    }
+}
+
+/*
+ * Expose the function on the window object
+ */
+
+//use amd or just through the window object.
+if (window) {
+    if (typeof window.define == "function" && window.define.amd) {
+        window.define("jwt_decode", function () {
+            return jwtDecode;
+        });
+    } else if (window) {
+        window.jwt_decode = jwtDecode;
+    }
+}
+
+export {jwtDecode as default}

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,26 +1,28 @@
+// methods for the search page
+import jwt_decode from "./jwt-decode.js";
+
 function updateUsername() {
-    const username = Cookies.get('Username');
-    if (username) {
-        console.log(`username is ${username}`);
+    const jwt = Cookies.get("JWT");
+    let username = "guest";
+
+    if (jwt) {
+        console.log("The JWT token is: ", jwt);
+
+        const decodedJWT = jwt_decode(jwt);
+
+        username = decodedJWT.username;
+        console.log(`The current Logged-in username is ${decodedJWT.username}`)
     } else {
-        console.log("user is not logged in.");
+        console.log("The session has expired.");
+        return;
     }
 
-    const jwtToken = Cookies.get("JWT");
-    // if JWT is present then the session is still valid, otherwise JWT token will be removed
-    if (jwtToken) {
-        console.log(`Decoded JWT token ${jwtToken}`);
-    } else {
-        console.log("log in expired.");
-    }
+    document.getElementById("login").style.display = "none";
+    document.getElementById("signup").style.display = "none";
 
-    if (username && jwtToken) {
-        document.getElementById("login").style.display = "none";
-        document.getElementById("signup").style.display = "none";
+    const userNameElement = document.getElementById("username");
+    userNameElement.innerText = username;
 
-        const userNameElement = document.getElementById("username");
-        userNameElement.innerText = username;
-    }
 }
 
 updateUsername();
@@ -48,8 +50,8 @@ function locateMe() {
                     if (month < 10) {
                         month = "0" + month.toString();
                     }
-                    let day = today.getDate(); 
-                    if (day < 10) { 
+                    let day = today.getDate();
+                    if (day < 10) {
                         day = "0" + day.toString();
                     }
                     document.getElementById("datepicker").value = [today.getFullYear(), month, day].join("-");
@@ -73,47 +75,9 @@ const locationSearchInput = document.getElementById('location');
 const spinner = document.getElementById("searchSpinner");
 locationSearchInput.addEventListener(
     "keyup", (evt) => {
-        if (evt.key == "Enter") {
+        if (evt.key === "Enter") {
             console.log("Pressed Enter in location input!")
             spinner.classList.remove("visually-hidden");
-        }    
+        }
     }
 )
-
-const cities = [
-    "San Jose",
-    "San Diego",
-    "San Francisco",
-    "Los Angeles",
-    "New York",
-    "Chicago",
-    "Houston",
-    "Philadelphia",
-    "Phoenix",
-    "San Antonio",
-    "Dallas",
-    "Indianapolis",
-    "Austin",
-    "Columbus",
-    "Baltimore",
-    "Boston",
-    "Seattle",
-    "Washington",
-    "Portland",
-    "Las Vegas",
-    "Paris",
-    "Rome",
-    "Vancouver",
-    "New Delhi",
-    "Beijing",
-    "Shanghai",
-];
-
-const countries = [
-    "USA",
-    "Italy",
-    "France",
-    "Canada",
-    "China",
-    "India",
-]

--- a/iowrappers/maps_client.go
+++ b/iowrappers/maps_client.go
@@ -58,7 +58,7 @@ func CreateLogger() error {
 	}
 
 	Logger = logger.Sugar()
-
+	Logger.Infof("current environment is %s", currentEnv)
 	return nil
 }
 

--- a/planner/planner_API.go
+++ b/planner/planner_API.go
@@ -3,7 +3,6 @@ package planner
 import (
 	"context"
 	"errors"
-	"fmt"
 	"html/template"
 	"io/ioutil"
 	"net/http"
@@ -152,7 +151,7 @@ func (planner *MyPlanner) ReverseGeocodingHandler(context *gin.Context) {
 }
 
 func (planner *MyPlanner) UserRatingsTotalMigrationHandler(context *gin.Context) {
-	_, authenticationErr := planner.UserAuthentication(context, context.Request, user.LevelAdmin)
+	_, authenticationErr := planner.UserAuthentication(context, user.LevelAdmin)
 	if authenticationErr != nil {
 		context.JSON(http.StatusUnauthorized, gin.H{"error": authenticationErr.Error()})
 		return
@@ -163,7 +162,7 @@ func (planner *MyPlanner) UserRatingsTotalMigrationHandler(context *gin.Context)
 }
 
 func (planner *MyPlanner) UrlMigrationHandler(context *gin.Context) {
-	_, authenticationErr := planner.UserAuthentication(context, context.Request, user.LevelAdmin)
+	_, authenticationErr := planner.UserAuthentication(context, user.LevelAdmin)
 	if authenticationErr != nil {
 		context.JSON(http.StatusUnauthorized, gin.H{"error": authenticationErr.Error()})
 		return
@@ -222,7 +221,6 @@ func (planner *MyPlanner) CityStatsHandler(context *gin.Context) {
 	context.JSON(http.StatusOK, view)
 }
 
-// Planning solves the single-day, single-city planning task
 func (planner *MyPlanner) Planning(ctx context.Context, planningRequest *solution.PlanningRequest, user string) (resp PlanningResponse) {
 	var planningResponse solution.PlanningResponse
 
@@ -279,7 +277,6 @@ func (planner *MyPlanner) Planning(ctx context.Context, planningRequest *solutio
 	return
 }
 
-// API definitions
 func (planner *MyPlanner) searchPageHandler(c *gin.Context) {
 	c.HTML(http.StatusOK, "search_page.html", gin.H{})
 }
@@ -324,13 +321,13 @@ func validateLocation(location string) error {
 	return nil
 }
 
-// HTTP GET API end-point
+// HTTP GET API end-point handler
 // Return top planning result to user
 func (planner *MyPlanner) getPlanningApi(ctx *gin.Context) {
 	var username = "guest" // default username
 	if strings.ToLower(planner.Environment) == "production" {
 		var authenticationErr error
-		username, authenticationErr = planner.UserAuthentication(ctx, ctx.Request, user.LevelRegular)
+		username, authenticationErr = planner.UserAuthentication(ctx, user.LevelRegular)
 		if authenticationErr != nil {
 			utils.LogErrorWithLevel(authenticationErr, utils.LogDebug)
 			planner.login(ctx)
@@ -449,7 +446,7 @@ func (planner MyPlanner) SetupRouter(serverPort string) *http.Server {
 
 func getPlaceIcon(placeTypes []POI.PlaceCategory, pIdx int) string {
 	if pIdx >= len(placeTypes) {
-		return fmt.Sprintf("%s", POI.PlaceIconEmpty)
+		return string(POI.PlaceIconEmpty)
 	}
-	return fmt.Sprintf("%s", placeTypeToIcon[placeTypes[pIdx]])
+	return string(placeTypeToIcon[placeTypes[pIdx]])
 }

--- a/solution/solver.go
+++ b/solution/solver.go
@@ -115,7 +115,7 @@ func (solver *Solver) Solve(context context.Context, redisClient iowrappers.Redi
 	cacheResponse, cacheErr := redisClient.PlanningSolutions(context, redisRequest)
 
 	if cacheErr == nil {
-		iowrappers.Logger.Debugf("Found slot cacheResponse in Redis for request %+v.", *request)
+		iowrappers.Logger.Debugf("Found planning solutions in Redis for request %+v.", *request)
 		for _, candidate := range cacheResponse.CachedPlanningSolutions {
 			planningSolution := PlanningSolution{
 				PlaceNames:      candidate.PlaceNames,

--- a/templates/search_page.html
+++ b/templates/search_page.html
@@ -87,8 +87,8 @@
 
     <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/js-cookie@rc/dist/js.cookie.min.js"></script>
-    <script type="module" src="assets/js/search.js">
-    </script>
+    <script type="module" src="assets/js/search.js"></script>
+    <script src="assets/js/jwt-decode.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Description
Previously, after users logged in, the backend server assigns both JWT and a username to the session cookies. The username cookie is redundant and confusing to the front-end as well as backend functions. In this change, we attempt to remove the username from the cookie assignments and extract the username from the JWT claims.

## Solution
* Use `jwt-decode` module to extract claims on the front-end
* Simplify backend user authentication methods
