### PR TITLE
Feature: Create docker compose file to enable the persistence layer

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,14 @@
+version: "3.9"
+services:
+  web:
+    build: .
+    environment:
+      MAPS_CLIENT_API_KEY: ${MAPS_CLIENT_API_KEY}
+      REDIS_URL: ${REDIS_URL}
+    ports:
+      - "10000:10000"
+  redis:
+    container_name: "redis"
+    image: "redis:alpine"
+    ports:
+      - "6379:6379"

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ type Config struct {
 		ServerPort string `envconfig:"PORT" default:"10000"`
 	}
 	Redis struct {
-		RedisUrl        string `envconfig:"REDISCLOUD_URL" default:"redis://localhost:6379"`
+		RedisUrl        string `envconfig:"REDIS_URL" default:"redis://localhost:6379"`
 		RedisStreamName string `default:"stream:planning_api_usage"`
 	}
 	MapsClientApiKey string `default:"YOUR_GOOGLE_API_KEY" split_words:"true"`


### PR DESCRIPTION
## Description
Containerize the entire planner.

## Solution

- Docker compose takes `.env` file on the local machine and inject them into the container
- Command: `docker compose up --build`

