### PR TITLE
Fix: Add administration area level one to user input location

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -31,8 +31,6 @@ function updateUsername() {
     userProfileElement.innerText = username;
 }
 
-updateUsername();
-
 function logOut() {
     const cookieToRemove = "JWT";
     const jwt = Cookies.get(cookieToRemove);
@@ -53,10 +51,8 @@ function locateMe() {
     async function success(location) {
         const latitude = location.coords.latitude;
         const longitude = location.coords.longitude;
-        const today = new Date();
 
-        console.log(latitude, longitude);
-        console.log(today);
+        console.log(`latitude ${latitude} and longitude: ${longitude}`);
 
         const url = "/v1/reverse-geocoding"
         await axios.get(url, {
@@ -69,15 +65,6 @@ function locateMe() {
                 response => {
                     const reverseGeocodingResults = response.data.results;
                     document.getElementById("location").value = [reverseGeocodingResults.city, reverseGeocodingResults.admin_area_level_one, reverseGeocodingResults.country].join(", ");
-                    let month = today.getMonth() + 1;
-                    if (month < 10) {
-                        month = "0" + month.toString();
-                    }
-                    let day = today.getDate();
-                    if (day < 10) {
-                        day = "0" + day.toString();
-                    }
-                    document.getElementById("datepicker").value = [today.getFullYear(), month, day].join("-");
                 }
             ).catch(
                 err => console.error(err)
@@ -91,6 +78,24 @@ function locateMe() {
         navigator.geolocation.getCurrentPosition(success, error);
     }
 }
+
+function setDateToday() {
+    const today = new Date();
+    console.log("today's date is: " + today);
+    let month = today.getMonth() + 1;
+    if (month < 10) {
+        month = "0" + month.toString();
+    }
+    let day = today.getDate();
+    if (day < 10) {
+        day = "0" + day.toString();
+    }
+    document.getElementById("datepicker").value = [today.getFullYear(), month, day].join("-");
+}
+
+updateUsername();
+
+setDateToday();
 
 document.querySelector('#autofill').addEventListener('click', locateMe);
 

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -41,7 +41,7 @@ function logOut() {
         return;
     }
     console.log(`JWT ${cookieToRemove} is removed`);
-    Cookies.remove(cookieToRemove, {path: "/v1"});
+    Cookies.remove(cookieToRemove, { path: "/v1" });
     location.reload();
 }
 
@@ -67,7 +67,8 @@ function locateMe() {
         })
             .then(
                 response => {
-                    document.getElementById("location").value = response.data.results.city + ", " + response.data.results.country;
+                    const reverseGeocodingResults = response.data.results;
+                    document.getElementById("location").value = [reverseGeocodingResults.city, reverseGeocodingResults.admin_area_level_one, reverseGeocodingResults.country].join(", ");
                     let month = today.getMonth() + 1;
                     if (month < 10) {
                         month = "0" + month.toString();

--- a/iowrappers/nearby_search.go
+++ b/iowrappers/nearby_search.go
@@ -202,7 +202,7 @@ func PlaceDetailedSearch(context context.Context, mapsClient *MapsClient, placeI
 func parsePlacesSearchResponse(resp maps.PlacesSearchResponse, locationType POI.LocationType, microAddrMap map[string]string, placeMap map[string]bool, urlMap map[string]string) (places []POI.Place) {
 	for _, res := range resp.Results {
 		id := res.PlaceID
-		if seen, _ := placeMap[id]; !seen {
+		if seen := placeMap[id]; !seen {
 			placeMap[id] = true
 		} else {
 			continue

--- a/iowrappers/poi_searcher.go
+++ b/iowrappers/poi_searcher.go
@@ -24,8 +24,9 @@ type PoiSearcher struct {
 
 // GeocodeQuery can also be used as the result of reverse geocoding
 type GeocodeQuery struct {
-	City    string `json:"city"`
-	Country string `json:"country"`
+	City              string `json:"city"`
+	AdminAreaLevelOne string `json:"admin_area_level_one"`
+	Country           string `json:"country"`
 }
 
 var Logger *zap.SugaredLogger
@@ -55,6 +56,7 @@ func (poiSearcher PoiSearcher) Geocode(context context.Context, query *GeocodeQu
 	originalGeocodeQuery := GeocodeQuery{}
 	originalGeocodeQuery.City = query.City
 	originalGeocodeQuery.Country = query.Country
+	originalGeocodeQuery.AdminAreaLevelOne = query.AdminAreaLevelOne
 	var geocodeMissingErr error
 	lat, lng, geocodeMissingErr = poiSearcher.redisClient.Geocode(context, query)
 	if geocodeMissingErr != nil {
@@ -62,7 +64,7 @@ func (poiSearcher PoiSearcher) Geocode(context context.Context, query *GeocodeQu
 		if err != nil {
 			return
 		}
-		// either redisClient or mapsClient may have corrected location name in the query
+		// either redisClient or mapsClient may have corrected location fields in the query
 		poiSearcher.redisClient.SetGeocode(context, *query, lat, lng, originalGeocodeQuery)
 		Logger.Debugf("Geolocation (lat,lng) Cache miss for location %s, %s is %.4f, %.4f",
 			query.City, query.Country, lat, lng)
@@ -75,8 +77,9 @@ func (poiSearcher PoiSearcher) NearbySearch(context context.Context, request *Pl
 
 	places := make([]POI.Place, 0)
 	lat, lng, err := poiSearcher.Geocode(context, &GeocodeQuery{
-		City:    location.City,
-		Country: location.Country,
+		City:              location.City,
+		AdminAreaLevelOne: location.AdminAreaLevelOne,
+		Country:           location.Country,
 	})
 	if logErr(err, utils.LogError) {
 		return places, err

--- a/iowrappers/redis_client.go
+++ b/iowrappers/redis_client.go
@@ -247,6 +247,10 @@ func (redisClient *RedisClient) CacheLocationAlias(context context.Context, quer
 	if err != nil {
 		return
 	}
+	_, err = redisClient.client.HSet(context, "location_name_alias_mapping:admin_area_level_one_names", strings.ToLower(query.AdminAreaLevelOne), strings.ToLower(correctedQuery.AdminAreaLevelOne)).Result()
+	if err != nil {
+		return
+	}
 	_, err = redisClient.client.HSet(context, "location_name_alias_mapping:country_names", strings.ToLower(query.Country), strings.ToLower(correctedQuery.Country)).Result()
 	if err != nil {
 		return
@@ -257,6 +261,7 @@ func (redisClient *RedisClient) CacheLocationAlias(context context.Context, quer
 // GetLocationWithAlias retrieves corrected location name from Redis; returns empty string if not exist;
 // corrects geocode query if corrected location name exists
 func (redisClient *RedisClient) GetLocationWithAlias(context context.Context, query *GeocodeQuery) string {
+	var err error
 	resCity, err := redisClient.client.HGet(context, "location_name_alias_mapping:city_names", strings.ToLower(query.City)).Result()
 	if err != nil {
 		return ""
@@ -267,15 +272,21 @@ func (redisClient *RedisClient) GetLocationWithAlias(context context.Context, qu
 		return ""
 	}
 
+	resAdminAreaLevelOne, err := redisClient.client.HGet(context, "location_name_alias_mapping:admin_area_level_one_names", strings.ToLower(query.AdminAreaLevelOne)).Result()
+	if err != nil {
+		return ""
+	}
+
 	query.Country = resCountry
 	query.City = resCity
-	return strings.Join([]string{resCity, resCountry}, "_")
+	query.AdminAreaLevelOne = resAdminAreaLevelOne
+	return strings.Join([]string{resCity, resAdminAreaLevelOne, resCountry}, "_")
 }
 
 func (redisClient *RedisClient) Geocode(context context.Context, query *GeocodeQuery) (lat float64, lng float64, err error) {
 	redisKey := "geocode:cities"
 	redisField := redisClient.GetLocationWithAlias(context, query)
-	errMsg := fmt.Errorf("geocode of location %s, %s does not exist in cache", query.City, query.Country)
+	errMsg := fmt.Errorf("geocode of location %s, %s, %s does not exist in cache", query.City, query.AdminAreaLevelOne, query.Country)
 	if redisField == "" {
 		err = errMsg
 		return
@@ -294,14 +305,15 @@ func (redisClient *RedisClient) Geocode(context context.Context, query *GeocodeQ
 
 func (redisClient *RedisClient) SetGeocode(context context.Context, query GeocodeQuery, lat float64, lng float64, originalQuery GeocodeQuery) {
 	redisKey := "geocode:cities"
-	redisField := strings.ToLower(strings.Join([]string{query.City, query.Country}, "_"))
-	redisVal := strings.Join([]string{fmt.Sprintf("%.6f", lat), fmt.Sprintf("%.6f", lng)}, ",") // 1/9 meter precision
-	_, err := redisClient.client.HSet(context, redisKey, redisField, redisVal).Result()
+	redisHashField := strings.ToLower(strings.Join([]string{query.City, query.AdminAreaLevelOne, query.Country}, "_"))
+	redisHashVal := strings.Join([]string{fmt.Sprintf("%.6f", lat), fmt.Sprintf("%.6f", lng)}, ",") // 1/9 meter precision
+	_, err := redisClient.client.HSet(context, redisKey, redisHashField, redisHashVal).Result()
 	utils.LogErrorWithLevel(err, utils.LogError)
 	if err != nil {
-		Logger.Errorf("Failed to cache geolocation for location %s, %s", query.City, query.Country)
+		Logger.Errorf("Failed to cache geolocation for location %s, %s with error %s", query.City, query.Country, err.Error())
+		return
 	} else {
-		Logger.Infof("Cached geolocation for location %s, %s success", query.City, query.Country)
+		Logger.Debugf("Cached geolocation for location %s, %s success", query.City, query.Country)
 	}
 	utils.LogErrorWithLevel(redisClient.CacheLocationAlias(context, originalQuery, query), utils.LogError)
 }
@@ -372,7 +384,7 @@ func encodePlanIndex(placeCategories []POI.PlaceCategory, intervals []POI.TimeIn
 }
 
 func generateTravelPlansCacheKey(req PlanningSolutionsCacheRequest) (string, error) {
-	country, city := req.Location.Country, req.Location.City
+	country, region, city := req.Location.Country, req.Location.AdminAreaLevelOne, req.Location.City
 	planIndex, err := encodePlanIndex(req.PlaceCategories, req.Intervals)
 	if err != nil {
 		return "", err
@@ -382,9 +394,10 @@ func generateTravelPlansCacheKey(req PlanningSolutionsCacheRequest) (string, err
 	planIndexStr := strconv.FormatUint(planIndex, 10)
 
 	country = strings.ReplaceAll(strings.ToLower(country), " ", "_")
+	region = strings.ReplaceAll(strings.ToLower(region), " ", "_")
 	city = strings.ReplaceAll(strings.ToLower(city), " ", "_")
 
-	redisFieldKey := strings.ToLower(strings.Join([]string{TravelPlansRedisCacheKeyPrefix, country, city, radius, strconv.Itoa(int(req.Weekday)), planIndexStr}, ":"))
+	redisFieldKey := strings.ToLower(strings.Join([]string{TravelPlansRedisCacheKeyPrefix, country, region, city, radius, strconv.Itoa(int(req.Weekday)), planIndexStr}, ":"))
 	return redisFieldKey, nil
 }
 

--- a/iowrappers/transformers.go
+++ b/iowrappers/transformers.go
@@ -11,6 +11,8 @@ func geocodingResultsToGeocodeQuery(results []maps.GeocodingResult) GeocodeQuery
 			switch addressType {
 			case "locality":
 				reverseGeocodingResult.City = component.LongName
+			case "administrative_area_level_1":
+				reverseGeocodingResult.AdminAreaLevelOne = component.ShortName
 			case "country":
 				reverseGeocodingResult.Country = component.LongName
 			}

--- a/solution/solver.go
+++ b/solution/solver.go
@@ -52,8 +52,9 @@ func (solver *Solver) Init(poiSearcher *iowrappers.PoiSearcher) {
 
 func (solver *Solver) ValidateLocation(context context.Context, location *POI.Location) bool {
 	geoQuery := iowrappers.GeocodeQuery{
-		City:    location.City,
-		Country: location.Country,
+		City:              location.City,
+		AdminAreaLevelOne: location.AdminAreaLevelOne,
+		Country:           location.Country,
 	}
 	_, _, err := solver.Searcher.Geocode(context, &geoQuery)
 	if err != nil {

--- a/templates/search_page.html
+++ b/templates/search_page.html
@@ -107,7 +107,7 @@
 
                     <div class="flex-fill">
                         <input class="form-control border-0" type="search" id="location" placeholder="Search"
-                            aria-label="Search" name="location" value="Los Angeles, USA" list="datalistOptions">
+                            aria-label="Search" name="location" value="Los Angeles, CA, USA" list="datalistOptions">
 
                         <datalist id="datalistOptions">
                             <option value="San Francisco, USA">

--- a/test/redis_client_mocks/geocoding_cache_test.go
+++ b/test/redis_client_mocks/geocoding_cache_test.go
@@ -8,20 +8,29 @@ import (
 
 func TestGeoCodingCache(t *testing.T) {
 	geoCodeQuery := iowrappers.GeocodeQuery{
-		City:    "New York City",
-		Country: "US",
+		City:              "New York City",
+		AdminAreaLevelOne: "New York",
+		Country:           "US",
 	}
 	expectedLat := 40.7128
 	expectedLng := -74.0060
-
-	_ = iowrappers.CreateLogger()
 
 	RedisClient.SetGeocode(RedisContext, geoCodeQuery, expectedLat, expectedLng, geoCodeQuery)
 
 	lat, lng, geocodeMissingErr := RedisClient.Geocode(RedisContext, &geoCodeQuery)
 
-	if geocodeMissingErr != nil || lat != expectedLat || lng != expectedLng {
-		t.Errorf("geo-coding for %s fails",
-			strings.Join([]string{geoCodeQuery.City, geoCodeQuery.Country}, ","))
+	if geocodeMissingErr != nil {
+		t.Errorf("geo-coding for %s fails, error is %s",
+			strings.Join([]string{geoCodeQuery.City, geoCodeQuery.Country}, ","), geocodeMissingErr.Error())
+		return
+	}
+
+	if lat != expectedLat {
+		t.Errorf("expected lat %.4f got %.4f", expectedLat, lat)
+		return
+	}
+
+	if lng != expectedLng {
+		t.Errorf("expected lng %.4f got %.4f", expectedLng, lng)
 	}
 }


### PR DESCRIPTION
## Description
When searching cities with same name, the planner always uses the most popular city. This is not ideal especially when using Autofill.

## Root Cause
Location handling mechanisms lacking `Administration area level one` info.

## Solution
Add `Administration area level one` info and allow users to enter either `City, Country` or `City, Region, Country` in the search bar.


## Final Checks
- [x] Have you removed commented code ?
- [x] Have you used gofmt to format your code ?
- [x] You have added unit tests
