### PR TITLE
Fix issue of broken back button in mobile browsers

### DIFF
--- a/templates/profile_page.html
+++ b/templates/profile_page.html
@@ -24,7 +24,7 @@
     {{$username := .Username}}
     <nav class="navbar navbar-light navbar-expand-lg" style="background-color: #e3f2fd;">
         <div class="container-fluid">
-            <a class="nav-link" onclick="history.back()" href="#">Back</a>
+            <a class="nav-link" href="javascript:history.back()">Back</a>
             <span class="navbar-text" id="user-profile"> {{.Username}} </span>
         </div>
     </nav>

--- a/templates/trip_plan_details_template.html
+++ b/templates/trip_plan_details_template.html
@@ -19,7 +19,7 @@
     <div class="header">
         <nav class="navbar navbar-light" style="background-color: #e3f2fd;">
             <div class="container-fluid">
-                <a class="nav-link" onclick="history.back(-1)" href="#">Back</a>
+                <a class="nav-link" href="javascript:history.back()">Back</a>
                 <span class="navbar-text" id="user-profile"> guest </span>
             </div>
         </nav>


### PR DESCRIPTION
Fix issue #205 

## Description
Clearly describe changes in your PR, new feature or bug fixes

The "Back" link on the trip result page works in laptop browser and Android phones but NOT on iphones. 

## Root Cause
Briefly describe the root cause and analysis of the problem

Not sure, seems to os-related compatibility.. 

## Solution
Describe your code changes in detail for reviewers. Explain the solution and how it fixes the issue.
For new features, describe the high-level ideas.

Follow the suggested solution in one stack overflow post. Use inline javascript to directly update href attribute of the link.
https://stackoverflow.com/questions/8814472/how-to-make-an-html-back-link

## Testing
Did you add any new test for this change, performed manual integration tests, or both?

No new tests. Pass all existing tests.

## Final Checks
- [x] Have you removed commented code ?
- [x] Have you used gofmt to format your code ?
- [x] You have added unit tests
