### PR TITLE
Data migration: remove places without URL or photo reference in database

### DIFF
--- a/iowrappers/data_migrations_test.go
+++ b/iowrappers/data_migrations_test.go
@@ -1,0 +1,88 @@
+package iowrappers
+
+import (
+	"context"
+	"github.com/alicebob/miniredis/v2"
+	"github.com/weihesdlegend/Vacation-planner/POI"
+	"net/url"
+	"testing"
+)
+
+func TestRemovePlaces(t *testing.T) {
+	// set up
+	RedisMockSvr, _ := miniredis.Run()
+
+	redisUrl := "redis://" + RedisMockSvr.Addr()
+	redisURL, _ := url.Parse(redisUrl)
+	redisClient := CreateRedisClient(redisURL)
+	ctx := context.WithValue(context.Background(), "request_id", "r-33521-345")
+	_ = CreateLogger()
+
+	// create entities in the mock database
+	// a place without URL
+	placeA := POI.Place{
+		ID:           "33511",
+		Name:         "Rocky mountains",
+		LocationType: POI.LocationTypePark,
+		Location: POI.Location{
+			Latitude:  12.5635,
+			Longitude: 14.7834,
+		},
+		URL: "",
+		Photo: POI.PlacePhoto{
+			Reference: "www.rocky-mountains.com/photos",
+		},
+	}
+
+	// a place without photo
+	placeB := POI.Place{
+		ID:           "33512",
+		Name:         "Contemporary museum",
+		LocationType: POI.LocationTypeMuseum,
+		Location: POI.Location{
+			Latitude:  12.5734,
+			Longitude: 14.7912,
+		},
+		URL: "www.moma.com",
+		Photo: POI.PlacePhoto{
+			Reference: "",
+		},
+	}
+
+	var places []POI.Place
+	var err error
+	redisClient.SetPlacesOnCategory(ctx, []POI.Place{placeA, placeB})
+	places, _ = redisClient.NearbySearch(ctx, &PlaceSearchRequest{
+		PlaceCat: POI.PlaceCategoryVisit,
+		Location: POI.Location{
+			Latitude:  12.5636,
+			Longitude: 14.7813,
+		},
+		Radius: 10000,
+	})
+
+	if len(places) != 2 {
+		t.Errorf("expected number of places equals 2, got %d", len(places))
+		return
+	}
+
+	err = redisClient.RemovePlaces(ctx, []PlaceDetailsFields{PlaceDetailsFieldURL, PlaceDetailsFieldPhoto})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	places, _ = redisClient.NearbySearch(ctx, &PlaceSearchRequest{
+		PlaceCat: POI.PlaceCategoryVisit,
+		Location: POI.Location{
+			Latitude:  12.5636,
+			Longitude: 14.7813,
+		},
+		Radius: 10000,
+	})
+
+	if len(places) != 0 {
+		t.Errorf("expected number of places after removal equals 0, got %d", len(places))
+		return
+	}
+}

--- a/iowrappers/maps_client.go
+++ b/iowrappers/maps_client.go
@@ -59,6 +59,9 @@ func CreateLogger() error {
 	}
 
 	Logger = logger.Sugar()
+	if currentEnv == "" {
+		currentEnv = "TEST"
+	}
 	Logger.Infof("current environment is %s", currentEnv)
 	return nil
 }

--- a/iowrappers/redis_client.go
+++ b/iowrappers/redis_client.go
@@ -216,7 +216,7 @@ func (redisClient *RedisClient) NearbySearch(context context.Context, request *P
 		searchRadius = MaxSearchRadius
 	}
 
-	Logger.Debugf("[%s] Redis geo radius is using search radius of %d meters", context.Value(RequestIdKey), searchRadius)
+	Logger.Debugf("[%+v] Redis geo radius is using search radius of %d meters", context.Value(RequestIdKey), searchRadius)
 	geoQuery := redis.GeoRadiusQuery{
 		Radius: float64(searchRadius),
 		Unit:   "m",

--- a/iowrappers/utils.go
+++ b/iowrappers/utils.go
@@ -1,0 +1,31 @@
+package iowrappers
+
+import (
+	"context"
+	"errors"
+	"github.com/modern-go/reflect2"
+)
+
+func scanRedisKeys(context context.Context, redisClient *RedisClient, redisKeyPrefix string) ([]string, error) {
+	var redisKeys []string
+	if reflect2.IsNil(redisClient) {
+		return redisKeys, errors.New("redis client pointer is nil")
+	}
+
+	var cursor uint64
+	for {
+		var err error
+		var keys []string
+		keys, cursor, err = redisClient.client.Scan(context, cursor, redisKeyPrefix+"*", 100).Result()
+		if err != nil {
+			return redisKeys, err
+		}
+
+		redisKeys = append(redisKeys, keys...)
+
+		if cursor == 0 {
+			break
+		}
+	}
+	return redisKeys, nil
+}

--- a/planner/planner_APIs.go
+++ b/planner/planner_APIs.go
@@ -203,6 +203,18 @@ func (planner *MyPlanner) UrlMigrationHandler(context *gin.Context) {
 	}
 }
 
+func (planner *MyPlanner) removePlacesMigrationHandler(context *gin.Context) {
+	_, authenticationErr := planner.UserAuthentication(context, user.LevelAdmin)
+	if authenticationErr != nil {
+		context.JSON(http.StatusUnauthorized, gin.H{"error": authenticationErr.Error()})
+		return
+	}
+	if err := planner.Solver.Searcher.RemovePlaces(context, []iowrappers.PlaceDetailsFields{iowrappers.PlaceDetailsFieldURL, iowrappers.PlaceDetailsFieldPhoto}); err != nil {
+		context.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+}
+
 func (planner *MyPlanner) PlaceStatsHandler(context *gin.Context) {
 	var placeCount int
 	var err error
@@ -530,6 +542,7 @@ func (planner MyPlanner) SetupRouter(serverPort string) *http.Server {
 		{
 			migrations.GET("/user-ratings-total", planner.UserRatingsTotalMigrationHandler)
 			migrations.GET("/url", planner.UrlMigrationHandler)
+			migrations.GET("/remove-places", planner.removePlacesMigrationHandler)
 		}
 
 		users := v1.Group("/users")


### PR DESCRIPTION
## Description
We noticed that a significant number of places data in production have incomplete fields, resulting in plans missing URLs or photo references. This deficiency is breaking our features such as trip details.

## Root Cause
When adding new fields such as photos, older places data become stale. Furthermore, some original data from Google lack those fields.

## Solution
* Remove places without URL or photo reference in database.
* Only admins can trigger the data migration.


## Final Checks
- [x] Have you removed commented code ?
- [x] Have you used gofmt to format your code ?
- [x] You have added unit tests
