### PR TITLE
Fix incorrect sequence of PlaceIds in travel plan stored in Redis

### DIFF
--- a/solution/planning_solutions.go
+++ b/solution/planning_solutions.go
@@ -8,12 +8,12 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/yourbasic/radix"
 
 	"github.com/weihesdlegend/Vacation-planner/POI"
 	"github.com/weihesdlegend/Vacation-planner/graph"
 	"github.com/weihesdlegend/Vacation-planner/iowrappers"
 	"github.com/weihesdlegend/Vacation-planner/matching"
-	"github.com/yourbasic/radix"
 )
 
 const (
@@ -185,7 +185,8 @@ func TravelPlansDeduplication(travelPlans []PlanningSolution) []PlanningSolution
 	results := make([]PlanningSolution, 0)
 
 	for _, travelPlan := range travelPlans {
-		placeIds := travelPlan.PlaceIDS
+		placeIds := make([]string, len(travelPlan.PlaceIDS))
+		copy(placeIds, travelPlan.PlaceIDS)
 		radix.Sort(placeIds)
 		jointPlanIds := strings.Join(placeIds, "_")
 		if _, exists := duplicatedPlans[jointPlanIds]; !exists {


### PR DESCRIPTION
## Description
Clearly describe changes in your PR, new feature or bug fixes

Fix issue #203

## Root Cause
Briefly describe the root cause and analysis of the problem

Somehow `placeIds` is just a reference of `travelPlan.PlaceIDs` in the `TravelPlansDeduplication` function, so `radix.Sort(placeIds)` also unexpectedly alters the sequence of Place IDs in travel plan.

## Solution
Describe your code changes in detail for reviewers. Explain the solution and how it fixes the issue.
For new features, describe the high-level ideas.

Make a new copy of `travelPlan.PlaceIDs`

## Testing
Did you add any new test for this change, performed manual integration tests, or both?

Pass existing unit tests

## Final Checks
- [ ] Have you removed commented code ?
- [ ] Have you used gofmt to format your code ?
- [ ] You have added unit tests
