### PR TITLE
Refactor: Add type to price level

### DIFF
--- a/POI/places.go
+++ b/POI/places.go
@@ -46,7 +46,7 @@ type Place struct {
 	Address          Address        `bson:"address"`
 	FormattedAddress string         `bson:"formatted_address"`
 	Location         Location       `bson:"location"`
-	PriceLevel       int            `bson:"price_level"`
+	PriceLevel       PriceLevel     `bson:"price_level,string"`
 	Rating           float32        `bson:"rating"`
 	Hours            [7]string      `bson:"hours"`
 	URL              string         `bson:"url"`
@@ -71,6 +71,17 @@ type Address struct {
 	PostalCode   string
 	Country      string
 }
+
+type PriceLevel int
+
+const (
+	PriceLevelZero    = 0
+	PriceLevelOne     = 1
+	PriceLevelTwo     = 2
+	PriceLevelThree   = 3
+	PriceLevelFour    = 4
+	PriceLevelDefault = 2
+)
 
 func (place *Place) GetName() string {
 	return place.Name
@@ -109,7 +120,7 @@ func (place *Place) GetLocation() Location {
 	return place.Location
 }
 
-func (place *Place) GetPriceLevel() int {
+func (place *Place) GetPriceLevel() PriceLevel {
 	return place.PriceLevel
 }
 
@@ -216,7 +227,20 @@ func (place *Place) SetLocationCoordinates(coordinates [2]float64) {
 }
 
 func (place *Place) SetPriceLevel(priceRange int) {
-	place.PriceLevel = priceRange
+	switch priceRange {
+	case 0:
+		place.PriceLevel = PriceLevelZero
+	case 1:
+		place.PriceLevel = PriceLevelOne
+	case 2:
+		place.PriceLevel = PriceLevelTwo
+	case 3:
+		place.PriceLevel = PriceLevelThree
+	case 4:
+		place.PriceLevel = PriceLevelFour
+	default:
+		place.PriceLevel = PriceLevelDefault
+	}
 }
 
 func (place *Place) SetRating(rating float32) {

--- a/matching/models.go
+++ b/matching/models.go
@@ -7,6 +7,6 @@ type PlaceView struct {
 	URL          string    `json:"url"`
 	Rating       float32   `json:"rating"`
 	RatingsCount int       `json:"ratings_count"`
-	PriceLevel   int       `json:"price_level"`
+	AveragePrice float64   `json:"average_price"`
 	Hours        [7]string `json:"hours"`
 }

--- a/matching/places.go
+++ b/matching/places.go
@@ -70,7 +70,7 @@ func CreatePlace(place POI.Place, category POI.PlaceCategory) Place {
 	Place_ := Place{}
 	Place_.Place = &place
 	Place_.Address = place.GetFormattedAddress()
-	Place_.Price = Pricing(place.GetPriceLevel())
+	Place_.Price = AveragePricing(place.GetPriceLevel())
 	Place_.Category = category
 	return Place_
 }

--- a/matching/pricing.go
+++ b/matching/pricing.go
@@ -1,27 +1,30 @@
 package matching
 
+import "github.com/weihesdlegend/Vacation-planner/POI"
+
 const (
-	PriceLevelDefault = -1.0
-	PriceLevel0       = 0.0
-	PriceLevel1       = 10.0
-	PriceLevel2       = 30.0
-	PriceLevel3       = 50.0
-	PriceLevel4       = 100.0
+	PriceZeroMean    = 0.0
+	PriceOneMean     = 10.0
+	PriceTwoMean     = 30.0
+	PriceThreeMean   = 50.0
+	PriceFourMean    = 100.0
+	PriceDefaultMean = PriceTwoMean
 )
 
-func Pricing(priceLevel int) float64 {
+// AveragePricing returns expected price of the price level
+func AveragePricing(priceLevel POI.PriceLevel) float64 {
 	switch priceLevel {
-	case 0:
-		return PriceLevel0
-	case 1:
-		return PriceLevel1
-	case 2:
-		return PriceLevel2
-	case 3:
-		return PriceLevel3
-	case 4:
-		return PriceLevel4
+	case POI.PriceLevelZero:
+		return PriceZeroMean
+	case POI.PriceLevelOne:
+		return PriceOneMean
+	case POI.PriceLevelTwo:
+		return PriceTwoMean
+	case POI.PriceLevelThree:
+		return PriceThreeMean
+	case POI.PriceLevelFour:
+		return PriceFourMean
 	default:
-		return PriceLevelDefault
+		return PriceDefaultMean
 	}
 }

--- a/matching/score.go
+++ b/matching/score.go
@@ -1,4 +1,4 @@
-// score design doc: https://bit.ly/2OTuBhM
+// Package matching score design doc: https://bit.ly/2OTuBhM
 package matching
 
 import (
@@ -10,7 +10,7 @@ import (
 
 const (
 	AvgRating  = 3.0
-	AvgPricing = PriceLevel2
+	AvgPricing = PriceDefaultMean
 )
 
 func Score(places []Place) float64 {

--- a/matching/transformers.go
+++ b/matching/transformers.go
@@ -8,7 +8,7 @@ func ToPlaceView(place Place) PlaceView {
 		URL:          place.GetURL(),
 		Rating:       place.GetRating(),
 		RatingsCount: place.GetUserRatingsCount(),
-		PriceLevel:   place.Place.GetPriceLevel(),
+		AveragePrice: place.GetPrice(),
 		Hours:        place.GetHours(),
 	}
 	return placeView

--- a/test/create_visit_location_test.go
+++ b/test/create_visit_location_test.go
@@ -38,8 +38,8 @@ func TestCreatePlace(t *testing.T) {
 		t.Errorf("Address setting is not correct. \n Expected: %s \n Got: %s",
 			addr, place.GetAddress())
 	}
-	if place.GetPriceLevel() != 3 {
-		t.Errorf("Price level setting is not correct. \n Expected: %d \n Got: %d",
+	if place.GetPriceLevel() != POI.PriceLevelThree {
+		t.Errorf("Price level setting is not correct. \n Expected: %d \n Got: %+v",
 			3, place.GetPriceLevel())
 	}
 	if place.GetRating() != 4.5 {

--- a/test/redis_client_mocks/nearby_search_test.go
+++ b/test/redis_client_mocks/nearby_search_test.go
@@ -16,7 +16,7 @@ func TestGetPlaces(t *testing.T) {
 		Address:          POI.Address{},
 		FormattedAddress: "20 W 34th St, New York, NY 10001",
 		Location:         POI.Location{Longitude: -73.9857, Latitude: 40.7484},
-		PriceLevel:       3,
+		PriceLevel:       POI.PriceLevelThree,
 		Rating:           4.6,
 		Hours:            [7]string{},
 	}
@@ -28,7 +28,7 @@ func TestGetPlaces(t *testing.T) {
 		Address:          POI.Address{},
 		FormattedAddress: "255 Northern Blvd, Great Neck, NY 11021",
 		Location:         POI.Location{Longitude: -73.7271, Latitude: 40.7773},
-		PriceLevel:       5,
+		PriceLevel:       POI.PriceLevelFour,
 		Rating:           4.9,
 		Hours:            [7]string{},
 	}
@@ -40,7 +40,7 @@ func TestGetPlaces(t *testing.T) {
 		Address:          POI.Address{},
 		FormattedAddress: "72 W 36th St, New York, NY 10018",
 		Location:         POI.Location{Longitude: -73.98597, Latitude: 40.750706},
-		PriceLevel:       5,
+		PriceLevel:       POI.PriceLevelFour,
 		Rating:           4.6,
 		Hours:            [7]string{},
 	}

--- a/test/score_test.go
+++ b/test/score_test.go
@@ -9,7 +9,7 @@ import (
 func TestScoreFunction(t *testing.T) {
 	// test regular non-zero-price place
 	place1 := matching.CreatePlace(POI.Place{
-		PriceLevel:       3,
+		PriceLevel:       POI.PriceLevelThree,
 		Rating:           5.0,
 		UserRatingsTotal: 99,
 	}, POI.PlaceCategoryVisit)
@@ -23,7 +23,7 @@ func TestScoreFunction(t *testing.T) {
 
 	// test zero-price place
 	place2 := matching.CreatePlace(POI.Place{
-		PriceLevel:       0,
+		PriceLevel:       POI.PriceLevelZero,
 		Rating:           3.0,
 		UserRatingsTotal: 0,
 	}, POI.PlaceCategoryVisit)


### PR DESCRIPTION
## Description
Google Maps API provides price level from 0 to 4, previously the model is coupled with the range from the API. This change  attempts to reduce the coupling and ease further feature development.

## Final Checks
- [x] Have you removed commented code ?
- [x] Have you used gofmt to format your code ?
- [ ] You have added unit tests
