### PR TITLE
[Enhancement]Filter places business status operational

### DIFF
--- a/POI/places.go
+++ b/POI/places.go
@@ -41,7 +41,7 @@ const (
 type Place struct {
 	ID               string         `bson:"_id"`
 	Name             string         `bson:"name"`
-	Status           BusinessStatus `bson:"business_status"`
+	Status           BusinessStatus `bson:"status"`
 	LocationType     LocationType   `bson:"location_type"`
 	Address          Address        `bson:"address"`
 	FormattedAddress string         `bson:"formatted_address"`
@@ -62,6 +62,11 @@ type Location struct {
 	Country           string `json:"country"`           // name of the country where the location belongs to
 }
 
+// Address in adr micro-format example:
+// 665 3rd St.
+// Suite 207
+// San Francisco, CA 94107
+// U.S.A.
 type Address struct {
 	POBox        string
 	ExtendedAddr string
@@ -103,11 +108,6 @@ func (place *Place) GetID() string {
 	return place.ID
 }
 
-//Sample Address in adr micro-format
-//665 3rd St.
-//Suite 207
-//San Francisco, CA 94107
-//U.S.A.
 func (place *Place) GetAddress() Address {
 	return place.Address
 }
@@ -136,7 +136,6 @@ func (place *Place) GetUserRatingsTotal() int {
 	return place.UserRatingsTotal
 }
 
-// Set name if POI name changed
 func (place *Place) SetName(name string) {
 	place.Name = name
 }
@@ -154,17 +153,15 @@ func (place *Place) SetStatus(status string) {
 	}
 }
 
-// Set human-readable Address of this place
+// SetFormattedAddress sets a human-readable Address
 func (place *Place) SetFormattedAddress(formattedAddress string) {
 	place.FormattedAddress = formattedAddress
 }
 
-// Set type if POI type changed
 func (place *Place) SetType(t LocationType) {
 	place.LocationType = t
 }
 
-// Set time if POI opening hour changed for some day in a week
 func (place *Place) SetHour(day Weekday, hour string) {
 	switch day {
 	case DateSunday:

--- a/iowrappers/nearby_search.go
+++ b/iowrappers/nearby_search.go
@@ -27,6 +27,8 @@ type PlaceSearchRequest struct {
 	// minimum number of results, set this lower limit for reducing risk of zero result in upper-layer computations.
 	// suppose a location has more places established over time, this field would help trigger new searches to get those new establishments.
 	MinNumResults uint
+
+	BusinessStatus POI.BusinessStatus
 }
 
 func GoogleMapsNearbySearchWrapper(mapsClient MapsClient, location POI.Location, placeType string, radius uint, pageToken string) (resp maps.PlacesSearchResponse, err error) {

--- a/iowrappers/poi_searcher.go
+++ b/iowrappers/poi_searcher.go
@@ -131,6 +131,12 @@ func (poiSearcher PoiSearcher) NearbySearch(context context.Context, request *Pl
 		places = append(places, newPlaces...)
 	}
 
+	if request.BusinessStatus == POI.Operational {
+		totalPlacesCount := len(places)
+		places = filter(places, func(place POI.Place) bool { return place.Status == POI.Operational })
+		Logger.Debugf("%d places out of %d left after business status filtering", len(places), totalPlacesCount)
+	}
+
 	if uint(len(places)) < request.MinNumResults {
 		Logger.Debugf("Found %d POI results for place type %s, less than requested number of %d",
 			len(places), request.PlaceCat, request.MinNumResults)

--- a/iowrappers/redis_client.go
+++ b/iowrappers/redis_client.go
@@ -238,6 +238,12 @@ func (redisClient *RedisClient) NearbySearch(context context.Context, request *P
 			places = append(places, place)
 		}
 	}
+
+	if request.BusinessStatus == POI.Operational {
+		totalPlacesCount := len(places)
+		places = filter(places, func(place POI.Place) bool { return place.Status == POI.Operational })
+		Logger.Debugf("(RedisClient) NearbySearch -> %d places out of %d left after business status filtering", len(places), totalPlacesCount)
+	}
 	return
 }
 

--- a/iowrappers/utils.go
+++ b/iowrappers/utils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"github.com/modern-go/reflect2"
+	"github.com/weihesdlegend/Vacation-planner/POI"
 )
 
 func scanRedisKeys(context context.Context, redisClient *RedisClient, redisKeyPrefix string) ([]string, error) {
@@ -28,4 +29,15 @@ func scanRedisKeys(context context.Context, redisClient *RedisClient, redisKeyPr
 		}
 	}
 	return redisKeys, nil
+}
+
+// a generic filtering function for places
+func filter(places []POI.Place, condition func(place POI.Place) bool) []POI.Place {
+	var results []POI.Place
+	for _, place := range places {
+		if condition(place) {
+			results = append(results, place)
+		}
+	}
+	return results
 }

--- a/matching/matcher.go
+++ b/matching/matcher.go
@@ -41,10 +41,11 @@ func (matcher MatcherForPriceRange) Match(ctx context.Context, request Request) 
 
 	priceRangeFilterParams := filterParams.(PriceRangeFilterParams)
 	placeSearchRequest := &iowrappers.PlaceSearchRequest{
-		PlaceCat:      priceRangeFilterParams.Category,
-		Location:      request.Location,
-		Radius:        request.Radius,
-		MinNumResults: MinResultsForTimePeriodMatching,
+		PlaceCat:       priceRangeFilterParams.Category,
+		Location:       request.Location,
+		Radius:         request.Radius,
+		MinNumResults:  MinResultsForTimePeriodMatching,
+		BusinessStatus: POI.Operational,
 	}
 
 	basicPlaces, err := matcher.Searcher.NearbySearch(ctx, placeSearchRequest)
@@ -91,10 +92,11 @@ func (matcher MatcherForTime) Match(ctx context.Context, request Request) ([]Pla
 
 	timeFilterParams := filterParams.(TimeFilterParams)
 	placeSearchRequest := &iowrappers.PlaceSearchRequest{
-		PlaceCat:      timeFilterParams.Category,
-		Location:      request.Location,
-		Radius:        request.Radius,
-		MinNumResults: MinResultsForTimePeriodMatching,
+		PlaceCat:       timeFilterParams.Category,
+		Location:       request.Location,
+		Radius:         request.Radius,
+		MinNumResults:  MinResultsForTimePeriodMatching,
+		BusinessStatus: POI.Operational,
 	}
 
 	basicPlaces, err := matcher.Searcher.NearbySearch(ctx, placeSearchRequest)

--- a/templates/search_page.html
+++ b/templates/search_page.html
@@ -148,7 +148,6 @@
                 <div class="ps-1 pe-0 mt-1" id="priceDiv">
                     <select name="price" class="form-select border border-secondary"
                         aria-label=".form-select-sm example" id="priceToSelect" onchange="randomPriceRange(this)">
-                        <option>price</option>
                         <option value="0">$</option>
                         <option value="1">$$</option>
                         <option value="2">$$$</option>
@@ -157,12 +156,11 @@
                         <option value="0,1,2,3,4">Surprise</option>
                         <script>
                             function randomPriceRange() {
-                                var item = document.getElementById('priceToSelect');
-                                var valueSel = item.options[item.selectedIndex].text;
+                                const item = document.getElementById('priceToSelect');
+                                const valueSel = item.options[item.selectedIndex].text;
                                 if (valueSel === "Surprise") {
-                                    var index = Math.floor(Math.random() * 5);
-                                    var temp = item.value.split(",")[index];
-                                    item.value = temp;
+                                    const index = Math.floor(Math.random() * 5);
+                                    item.value = [0, 1, 2, 3, 4][index];
                                 }
                             }
                         </script>

--- a/test/redis_client_mocks/nearby_search_test.go
+++ b/test/redis_client_mocks/nearby_search_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestGetPlaces(t *testing.T) {
 	// set up data
-	places := make([]POI.Place, 3)
+	places := make([]POI.Place, 4)
 	places[0] = POI.Place{
 		ID:               "1001",
 		Name:             "Empire state building",
@@ -19,6 +19,7 @@ func TestGetPlaces(t *testing.T) {
 		PriceLevel:       POI.PriceLevelThree,
 		Rating:           4.6,
 		Hours:            [7]string{},
+		Status:           POI.Operational,
 	}
 
 	places[1] = POI.Place{
@@ -31,6 +32,7 @@ func TestGetPlaces(t *testing.T) {
 		PriceLevel:       POI.PriceLevelFour,
 		Rating:           4.9,
 		Hours:            [7]string{},
+		Status:           POI.Operational,
 	}
 
 	places[2] = POI.Place{
@@ -43,6 +45,20 @@ func TestGetPlaces(t *testing.T) {
 		PriceLevel:       POI.PriceLevelFour,
 		Rating:           4.6,
 		Hours:            [7]string{},
+		Status:           POI.ClosedPermanently,
+	}
+
+	places[3] = POI.Place{
+		ID:               "4004",
+		Name:             "The Morgan Library & Museum",
+		LocationType:     POI.LocationTypeMuseum,
+		Address:          POI.Address{},
+		FormattedAddress: "225 Madison Ave, New York, NY 10016",
+		Location:         POI.Location{Longitude: -73.9878, Latitude: 40.7496},
+		PriceLevel:       POI.PriceLevelThree,
+		Rating:           4.6,
+		Hours:            [7]string{},
+		Status:           POI.ClosedTemporarily,
 	}
 
 	_ = iowrappers.CreateLogger()
@@ -60,10 +76,11 @@ func TestGetPlaces(t *testing.T) {
 	// test normal cases
 	nycLatLng := POI.Location{Longitude: -74.006000, Latitude: 40.712800}
 	placeSearchRequest := iowrappers.PlaceSearchRequest{
-		Location:      nycLatLng,
-		PlaceCat:      "Visit",
-		Radius:        uint(5000),
-		MinNumResults: 1,
+		Location:       nycLatLng,
+		PlaceCat:       POI.PlaceCategoryVisit,
+		Radius:         uint(5000),
+		MinNumResults:  1,
+		BusinessStatus: POI.Operational,
 	}
 
 	cachedVisitPlaces, _ := RedisClient.NearbySearch(RedisContext, &placeSearchRequest)
@@ -77,7 +94,7 @@ func TestGetPlaces(t *testing.T) {
 	// OUTSIDE the search radius coverage
 	placeSearchRequest = iowrappers.PlaceSearchRequest{
 		Location:      nycLatLng,
-		PlaceCat:      "Eatery",
+		PlaceCat:      POI.PlaceCategoryEatery,
 		Radius:        uint(5000),
 		MinNumResults: 2,
 	}
@@ -90,7 +107,7 @@ func TestGetPlaces(t *testing.T) {
 	}
 
 	// expect to return empty slice if total number of cached places in a category is less than requested minimum
-	cachedVisitPlaces, _ = RedisClient.NearbySearch(RedisContext, &iowrappers.PlaceSearchRequest{MinNumResults: 2, PlaceCat: "Visit"})
+	cachedVisitPlaces, _ = RedisClient.NearbySearch(RedisContext, &iowrappers.PlaceSearchRequest{MinNumResults: 2, PlaceCat: POI.PlaceCategoryVisit})
 	if len(cachedVisitPlaces) != 0 {
 		t.Error("should return empty slice if total number of cached places in a category is less than requested minimum")
 	}

--- a/test/redis_client_mocks/nearby_search_test.go
+++ b/test/redis_client_mocks/nearby_search_test.go
@@ -1,15 +1,14 @@
 package redis_client_mocks
 
 import (
+	log "github.com/sirupsen/logrus"
 	"github.com/weihesdlegend/Vacation-planner/POI"
 	"github.com/weihesdlegend/Vacation-planner/iowrappers"
 	"testing"
 )
 
-func TestGetPlaces(t *testing.T) {
-	// set up data
-	places := make([]POI.Place, 4)
-	places[0] = POI.Place{
+var places = []POI.Place{
+	{
 		ID:               "1001",
 		Name:             "Empire state building",
 		LocationType:     POI.LocationTypeMuseum,
@@ -20,9 +19,8 @@ func TestGetPlaces(t *testing.T) {
 		Rating:           4.6,
 		Hours:            [7]string{},
 		Status:           POI.Operational,
-	}
-
-	places[1] = POI.Place{
+	},
+	{
 		ID:               "2002",
 		Name:             "Peter Luger's Steakhouse",
 		LocationType:     POI.LocationTypeRestaurant,
@@ -33,22 +31,20 @@ func TestGetPlaces(t *testing.T) {
 		Rating:           4.9,
 		Hours:            [7]string{},
 		Status:           POI.Operational,
-	}
-
-	places[2] = POI.Place{
+	},
+	{
 		ID:               "3003",
 		Name:             "Keens Steakhouse",
 		LocationType:     POI.LocationTypeRestaurant,
 		Address:          POI.Address{},
 		FormattedAddress: "72 W 36th St, New York, NY 10018",
-		Location:         POI.Location{Longitude: -73.98597, Latitude: 40.750706},
+		Location:         POI.Location{Longitude: -73.9859, Latitude: 40.7507},
 		PriceLevel:       POI.PriceLevelFour,
 		Rating:           4.6,
 		Hours:            [7]string{},
-		Status:           POI.ClosedPermanently,
-	}
-
-	places[3] = POI.Place{
+		Status:           POI.Operational,
+	},
+	{
 		ID:               "4004",
 		Name:             "The Morgan Library & Museum",
 		LocationType:     POI.LocationTypeMuseum,
@@ -59,27 +55,47 @@ func TestGetPlaces(t *testing.T) {
 		Rating:           4.6,
 		Hours:            [7]string{},
 		Status:           POI.ClosedTemporarily,
-	}
+	},
+}
 
-	_ = iowrappers.CreateLogger()
-
+func init() {
 	// cache places
 	RedisClient.SetPlacesOnCategory(RedisContext, places)
 
 	// if place are not cached, it is possibly because of GeoAdd failure
 	for _, place := range places {
 		if !RedisMockSvr.Exists("place_details:place_ID:" + place.ID) {
-			t.Errorf("place with ID %s does not exist in Redis", place.ID)
+			log.Errorf("place with ID %s does not exist in Redis", place.ID)
 		}
 	}
+}
 
-	// test normal cases
-	nycLatLng := POI.Location{Longitude: -74.006000, Latitude: 40.712800}
+// The setup of this test case guarantees that the Peter Luger's Steakhouse is located OUTSIDE the search radius coverage
+func TestGetPlaces_shouldExcludePlacesOutsideOfSearchRadius(t *testing.T) {
 	placeSearchRequest := iowrappers.PlaceSearchRequest{
-		Location:       nycLatLng,
+		Location: POI.Location{Longitude: -74.0060, Latitude: 40.7128},
+		PlaceCat: POI.PlaceCategoryEatery,
+		Radius:   uint(5000),
+	}
+
+	cachedEateryPlaces, err := RedisClient.NearbySearch(RedisContext, &placeSearchRequest)
+	if err != nil {
+		t.Errorf(err.Error())
+		return
+	}
+
+	if len(cachedEateryPlaces) != 1 || cachedEateryPlaces[0].ID != places[2].ID {
+		t.Logf("number of nearby eatery places obtained from Redis is %d", len(cachedEateryPlaces))
+		t.Error("failed to get cached Eatery place")
+	}
+}
+
+// The setup of this test case guarantees that the Morgan Library & Museum is within the search radius but is excluded due to temporary closure
+func TestGetPlaces_shouldExcludePlacesNotOperational(t *testing.T) {
+	placeSearchRequest := iowrappers.PlaceSearchRequest{
+		Location:       POI.Location{Longitude: -74.0060, Latitude: 40.7128},
 		PlaceCat:       POI.PlaceCategoryVisit,
-		Radius:         uint(5000),
-		MinNumResults:  1,
+		Radius:         uint(20000),
 		BusinessStatus: POI.Operational,
 	}
 
@@ -88,27 +104,5 @@ func TestGetPlaces(t *testing.T) {
 	if len(cachedVisitPlaces) != 1 || cachedVisitPlaces[0].ID != places[0].ID {
 		t.Logf("number of nearby visit places obtained from Redis is %d", len(cachedVisitPlaces))
 		t.Error("failed to get cached Visit place")
-	}
-
-	// the setup of this test case guarantees that the Peter Luger's Steakhouse is located
-	// OUTSIDE the search radius coverage
-	placeSearchRequest = iowrappers.PlaceSearchRequest{
-		Location:      nycLatLng,
-		PlaceCat:      POI.PlaceCategoryEatery,
-		Radius:        uint(5000),
-		MinNumResults: 2,
-	}
-
-	cachedEateryPlaces, _ := RedisClient.NearbySearch(RedisContext, &placeSearchRequest)
-
-	if len(cachedEateryPlaces) != 1 || cachedEateryPlaces[0].ID != places[2].ID {
-		t.Logf("number of nearby eatery places obtained from Redis is %d", len(cachedEateryPlaces))
-		t.Error("failed to get cached Eatery place")
-	}
-
-	// expect to return empty slice if total number of cached places in a category is less than requested minimum
-	cachedVisitPlaces, _ = RedisClient.NearbySearch(RedisContext, &iowrappers.PlaceSearchRequest{MinNumResults: 2, PlaceCat: POI.PlaceCategoryVisit})
-	if len(cachedVisitPlaces) != 0 {
-		t.Error("should return empty slice if total number of cached places in a category is less than requested minimum")
 	}
 }


### PR DESCRIPTION
## Description
Due to recent events such as COVID-19, many business are affected. As such place data from Google Maps tend to change relatively more frequently. Therefore it is important we filter out business that are temporarily closed or permanently closed.

## Root Cause
Planning results contain temporarily closed or permanently closed places.

## Solution
Filter non-operational places in the search client.


## Final Checks
- [x] Have you removed commented code ?
- [x] Have you used gofmt to format your code ?
- [x] You have added unit tests
