### PR TITLE
Fix the issue of seeing spinner when going back to the search page

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -46,5 +46,10 @@ locationSearchInput.addEventListener(
         }
     }
 )
+// hide spinner when switching pages
+const hideSpinner = function () {
+    spinner.classList.add("visually-hidden");
+}
+document.addEventListener("visibilitychange", hideSpinner);
 
 document.getElementById("profile").addEventListener("click", () => window.location = `/v1/users/${username}/profile`);


### PR DESCRIPTION
## Description
Clearly describe changes in your PR, new feature or bug fixes
The progress spinner was visible if we went back to the search page via hitting the back button on the browser. 
The spinner should be invisible in this case.

## Root Cause
Briefly describe the root cause and analysis of the problem
Spinner DOM property was cached in the browser, and when the browser traverse back in history. The "visible" state is used for the spinner DOM.

## Solution
Describe your code changes in detail for reviewers. Explain the solution and how it fixes the issue.
For new features, describe the high-level ideas.
Add a new HTML event listener to hide the spinner whenever there is visibility change of the page.

## Testing
Did you add any new test for this change, performed manual integration tests, or both?
Manually tested with both fast loading and slow loading. Results are as expected.

## Final Checks
- [x] Have you removed commented code ?
- [x] Have you used gofmt to format your code ?
