### PR TITLE
Fix: Out of memory while generating planning solutions

### DIFF
--- a/graph/vertex.go
+++ b/graph/vertex.go
@@ -12,6 +12,7 @@ type Vertex struct {
 	Neighbors []*Vertex // neighbor list
 	Location  Point     // geo-location
 	Parent    string    // parent name
+	Object    interface{}
 }
 
 // Point defines a location with latitude and longitude

--- a/test/solution_candidate_selection_test.go
+++ b/test/solution_candidate_selection_test.go
@@ -1,21 +1,38 @@
 package test
 
 import (
+	"github.com/weihesdlegend/Vacation-planner/POI"
+	"github.com/weihesdlegend/Vacation-planner/matching"
 	"github.com/weihesdlegend/Vacation-planner/solution"
 	"testing"
 )
 
 // test if priority queue gives top solution candidates
 func TestSolutionCandidateSelection(t *testing.T) {
-	candidates := make([]solution.PlanningSolution, 0)
+	places := make([]matching.Place, 0)
 
 	for i := 0; i < 100; i++ {
-		candidates = append(candidates, solution.PlanningSolution{Score: float64(i)})
+		places = append(places, matching.Place{Place: &POI.Place{Rating: float32(i), UserRatingsTotal: 9}, Price: 1})
 	}
 
-	res := solution.FindBestPlanningSolutions(candidates, 0)
+	iterator := &solution.MultiDimIterator{}
 
-	expectation := []float64{95, 96, 97, 98, 99}
+	clusters := make([][]matching.Place, 1)
+	clusters[0] = places
+	err := iterator.Init([]POI.PlaceCategory{POI.PlaceCategoryEatery}, clusters)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	topSolutionsCount := int64(5)
+	res := solution.FindBestPlanningSolutions(clusters, topSolutionsCount, iterator)
+
+	if int64(len(res)) != topSolutionsCount {
+		t.Errorf("expected number of solutions equals %d, got %d", topSolutionsCount, len(res))
+		return
+	}
+
+	expectation := []float64{94, 95, 96, 97, 98}
 	for idx, r := range res {
 		if r.Score != expectation[idx] {
 			t.Errorf("expected %f, got %f", expectation[idx], r.Score)


### PR DESCRIPTION
## Description
Previously the solver first compute all the planning solutions before sorting them by score with the priority queue. This creates a huge memory overhead when the number of requested categories is large (>4). We have seen multiple occurrences of out of memory error in production.

## Root Cause
The solver memorize all the solutions and then feed the list to ranker.

## Solution
Generate planning solutions and feed new solutions to ranker **at the same time**.

Note that the usage of `TravelPlansDeduplication` function is removed, there is currently no good solution to deduplicate permutation travel plans without incurring large memory footprints.

## Testing
Did you add any new test for this change, performed manual integration tests, or both? <-- Both


## Final Checks
- [x] Have you removed commented code ?
- [x] Have you used gofmt to format your code ?
- [x] You have added unit tests
