### PR TITLE
Feature: use precise location for travel planning

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -17,6 +17,9 @@
 div.fixedwidthicon {
     width: 25px;
 }
+button.square-button{
+    width: 31px;
+}
 
 h1 {
     text-align: center;
@@ -50,9 +53,6 @@ tr:nth-child(even) {
     }
     #locationDiv {
         min-width: 13em;
-    }
-    #priceDiv {
-        width: 6em;
     }
   }
 #planSaveIcon {

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,5 +1,5 @@
 // methods for the search page
-import { locateMe, setDateToday } from "./utils.js";
+import { locateMe, setDateToday, preciseLocation } from "./utils.js";
 
 import { logOut } from "./user.js";
 
@@ -35,6 +35,8 @@ document.getElementById("logout-confirm-btn").addEventListener(
 )
 
 document.querySelector('#autofill').addEventListener('click', locateMe);
+
+document.querySelector('#use-precise-location').addEventListener('click', preciseLocation);
 
 const locationSearchInput = document.getElementById('location');
 const spinner = document.getElementById("searchSpinner");

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -33,6 +33,20 @@ function locateMe() {
     }
 }
 
+function preciseLocation() {
+    if (navigator.geolocation) {
+        navigator.geolocation.getCurrentPosition(
+            async function (location) {
+                const latitude = location.coords.latitude;
+                const longitude = location.coords.longitude;
+                console.log(`latitude ${latitude} and longitude: ${longitude}`);
+                document.getElementById("location").value = longitude.toString() + ', ' + latitude.toString();
+                document.getElementById("precise-location-flag").value = "true";
+            }, (error) => { console.log(error) }
+        )
+    }
+}
+
 // set today's date for a datepicker element
 function setDateToday() {
     const today = new Date();
@@ -48,4 +62,4 @@ function setDateToday() {
     document.getElementById("datepicker").value = [today.getFullYear(), month, day].join("-");
 }
 
-export{ locateMe, setDateToday }
+export { locateMe, setDateToday, preciseLocation }

--- a/iowrappers/nearby_search.go
+++ b/iowrappers/nearby_search.go
@@ -29,6 +29,8 @@ type PlaceSearchRequest struct {
 	MinNumResults uint
 
 	BusinessStatus POI.BusinessStatus
+	// true if using precise geolocation instead of using a grander administrative area
+	UsePreciseLocation bool
 }
 
 func GoogleMapsNearbySearchWrapper(mapsClient MapsClient, location POI.Location, placeType string, radius uint, pageToken string) (resp maps.PlacesSearchResponse, err error) {

--- a/iowrappers/poi_searcher.go
+++ b/iowrappers/poi_searcher.go
@@ -74,6 +74,11 @@ func (poiSearcher PoiSearcher) Geocode(context context.Context, query *GeocodeQu
 	return
 }
 
+func (poiSearcher PoiSearcher) ReverseGeocode(ctx context.Context, lat, lng float64) (*GeocodeQuery, error) {
+	Logger.Debugf("PoiSearcher ->ReverseGeocode: decoding latitude %.2f, longitude %.2f", lat, lng)
+	return poiSearcher.mapsClient.ReverseGeocode(ctx, lat, lng)
+}
+
 func (poiSearcher PoiSearcher) NearbySearch(context context.Context, request *PlaceSearchRequest) ([]POI.Place, error) {
 	if err := poiSearcher.processLocation(context, request); err != nil {
 		return nil, err
@@ -125,7 +130,7 @@ func (poiSearcher PoiSearcher) processLocation(ctx context.Context, req *PlaceSe
 	location := &req.Location
 	if req.UsePreciseLocation {
 		Logger.Debugf("->NearbySearch: using precise location")
-		geoQuery, err := poiSearcher.GetMapsClient().ReverseGeocoding(ctx, req.Location.Latitude, req.Location.Longitude)
+		geoQuery, err := poiSearcher.GetMapsClient().ReverseGeocode(ctx, req.Location.Latitude, req.Location.Longitude)
 		if err != nil {
 			return err
 		}

--- a/iowrappers/poi_searcher.go
+++ b/iowrappers/poi_searcher.go
@@ -75,23 +75,13 @@ func (poiSearcher PoiSearcher) Geocode(context context.Context, query *GeocodeQu
 }
 
 func (poiSearcher PoiSearcher) NearbySearch(context context.Context, request *PlaceSearchRequest) ([]POI.Place, error) {
+	if err := poiSearcher.processLocation(context, request); err != nil {
+		return nil, err
+	}
 	location := request.Location
 
-	places := make([]POI.Place, 0)
-	lat, lng, err := poiSearcher.Geocode(context, &GeocodeQuery{
-		City:              location.City,
-		AdminAreaLevelOne: location.AdminAreaLevelOne,
-		Country:           location.Country,
-	})
-	if logErr(err, utils.LogError) {
-		return places, err
-	}
-
-	// update request.Location after the city,country conversion
-	request.Location.Latitude = lat
-	request.Location.Longitude = lng
-
-	var cachedPlaces []POI.Place
+	var cachedPlaces, places []POI.Place
+	var err error
 	cachedPlaces, err = poiSearcher.redisClient.NearbySearch(context, request)
 	if err != nil {
 		Logger.Error(err)
@@ -110,40 +100,81 @@ func (poiSearcher PoiSearcher) NearbySearch(context context.Context, request *Pl
 		return places, nil
 	}
 
-	cacheMiss = poiSearcher.redisClient.SetMapsLastSearchTime(context, location, request.PlaceCat, currentTime.Format(time.RFC3339))
-	utils.LogErrorWithLevel(cacheMiss, utils.LogError)
-
-	originalSearchRadius := request.Radius
-
-	request.Radius = MaxSearchRadius // use a large search radius whenever we call external maps services
+	utils.LogErrorWithLevel(poiSearcher.redisClient.SetMapsLastSearchTime(context, location, request.PlaceCat, currentTime.Format(time.RFC3339)), utils.LogError)
 
 	// initiate a new external search
-	newPlaces, mapsNearbySearchErr := poiSearcher.mapsClient.NearbySearch(context, request)
-	utils.LogErrorWithLevel(mapsNearbySearchErr, utils.LogError)
-
-	request.Radius = originalSearchRadius // restore search radius
-
-	// update Redis with all the new places obtained
-	poiSearcher.UpdateRedis(context, newPlaces)
+	newPlaces, searchErr := poiSearcher.searchPlacesWithMaps(context, request)
+	if searchErr != nil {
+		return nil, searchErr
+	}
 
 	// safeguard on accessing elements in a nil slice
 	if len(newPlaces) > 0 {
+		// update Redis with all the new places obtained
+		poiSearcher.UpdateRedis(context, newPlaces)
+
+		// include places from cache in the result
 		places = append(places, newPlaces...)
 	}
 
-	if request.BusinessStatus == POI.Operational {
+	return places, nil
+}
+
+//processLocation performs reverse geocoding for precise location to find city-level information and performs geocoding to find precise latitude and longitude values
+func (poiSearcher PoiSearcher) processLocation(ctx context.Context, req *PlaceSearchRequest) error {
+	location := &req.Location
+	if req.UsePreciseLocation {
+		Logger.Debugf("->NearbySearch: using precise location")
+		geoQuery, err := poiSearcher.GetMapsClient().ReverseGeocoding(ctx, req.Location.Latitude, req.Location.Longitude)
+		if err != nil {
+			return err
+		}
+		location.City = geoQuery.City
+		location.AdminAreaLevelOne = geoQuery.AdminAreaLevelOne
+		location.Country = geoQuery.Country
+		return nil
+	}
+
+	lat, lng, err := poiSearcher.Geocode(ctx, &GeocodeQuery{
+		City:              location.City,
+		AdminAreaLevelOne: location.AdminAreaLevelOne,
+		Country:           location.Country,
+	})
+	if err != nil {
+		return err
+	}
+	location.Latitude = lat
+	location.Longitude = lng
+	return nil
+}
+
+func (poiSearcher PoiSearcher) searchPlacesWithMaps(ctx context.Context, req *PlaceSearchRequest) ([]POI.Place, error) {
+	originalRadius := req.Radius
+
+	// use a large search radius whenever we call external maps services
+	req.Radius = MaxSearchRadius
+
+	places, err := poiSearcher.GetMapsClient().NearbySearch(ctx, req)
+
+	// restore search radius upon search completion
+	req.Radius = originalRadius
+	if err != nil {
+		return nil, err
+	}
+
+	if req.BusinessStatus == POI.Operational {
 		totalPlacesCount := len(places)
 		places = filter(places, func(place POI.Place) bool { return place.Status == POI.Operational })
 		Logger.Debugf("%d places out of %d left after business status filtering", len(places), totalPlacesCount)
 	}
 
-	if uint(len(places)) < request.MinNumResults {
+	if uint(len(places)) < req.MinNumResults {
 		Logger.Debugf("Found %d POI results for place type %s, less than requested number of %d",
-			len(places), request.PlaceCat, request.MinNumResults)
+			len(places), req.PlaceCat, req.MinNumResults)
 	}
 	if len(places) == 0 {
 		Logger.Debugf("No qualified POI result found in the given location %v, radius %d, and place type: %s",
-			request.Location, request.Radius, request.PlaceCat)
+			req.Location, req.Radius, req.PlaceCat)
 		Logger.Debug("location may be invalid")
 	}
 	return places, nil

--- a/iowrappers/redis_client.go
+++ b/iowrappers/redis_client.go
@@ -6,6 +6,7 @@ package iowrappers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -329,6 +330,10 @@ func (redisClient *RedisClient) Geocode(context context.Context, query *GeocodeQ
 	lat = latLng[0]
 	lng = latLng[1]
 	return
+}
+
+func (redisClient *RedisClient) ReverseGeocode(context.Context, float64, float64) (*GeocodeQuery, error) {
+	return nil, errors.New("->ReverseGeocode: not implemented for the RedisClient")
 }
 
 func (redisClient *RedisClient) SetGeocode(context context.Context, query GeocodeQuery, lat float64, lng float64, originalQuery GeocodeQuery) {

--- a/iowrappers/transformers.go
+++ b/iowrappers/transformers.go
@@ -2,7 +2,7 @@ package iowrappers
 
 import "googlemaps.github.io/maps"
 
-func geocodingResultsToGeocodeQuery(results []maps.GeocodingResult) GeocodeQuery {
+func geocodingResultsToGeocodeQuery(results []maps.GeocodingResult) *GeocodeQuery {
 	reverseGeocodingResult := GeocodeQuery{}
 	// take the most specific result
 	firstGeocodingResult := results[0]
@@ -18,5 +18,5 @@ func geocodingResultsToGeocodeQuery(results []maps.GeocodingResult) GeocodeQuery
 			}
 		}
 	}
-	return reverseGeocodingResult
+	return &reverseGeocodingResult
 }

--- a/matching/matcher.go
+++ b/matching/matcher.go
@@ -21,10 +21,11 @@ const (
 )
 
 type Request struct {
-	Radius   uint
-	Location POI.Location
-	Criteria FilterCriteria
-	Params   map[FilterCriteria]interface{}
+	Radius             uint
+	Location           POI.Location
+	Criteria           FilterCriteria
+	Params             map[FilterCriteria]interface{}
+	UsePreciseLocation bool
 }
 
 type MatcherForPriceRange struct {
@@ -41,11 +42,12 @@ func (matcher MatcherForPriceRange) Match(ctx context.Context, request Request) 
 
 	priceRangeFilterParams := filterParams.(PriceRangeFilterParams)
 	placeSearchRequest := &iowrappers.PlaceSearchRequest{
-		PlaceCat:       priceRangeFilterParams.Category,
-		Location:       request.Location,
-		Radius:         request.Radius,
-		MinNumResults:  MinResultsForTimePeriodMatching,
-		BusinessStatus: POI.Operational,
+		PlaceCat:           priceRangeFilterParams.Category,
+		Location:           request.Location,
+		Radius:             request.Radius,
+		MinNumResults:      MinResultsForTimePeriodMatching,
+		BusinessStatus:     POI.Operational,
+		UsePreciseLocation: request.UsePreciseLocation,
 	}
 
 	basicPlaces, err := matcher.Searcher.NearbySearch(ctx, placeSearchRequest)
@@ -92,11 +94,12 @@ func (matcher MatcherForTime) Match(ctx context.Context, request Request) ([]Pla
 
 	timeFilterParams := filterParams.(TimeFilterParams)
 	placeSearchRequest := &iowrappers.PlaceSearchRequest{
-		PlaceCat:       timeFilterParams.Category,
-		Location:       request.Location,
-		Radius:         request.Radius,
-		MinNumResults:  MinResultsForTimePeriodMatching,
-		BusinessStatus: POI.Operational,
+		PlaceCat:           timeFilterParams.Category,
+		Location:           request.Location,
+		Radius:             request.Radius,
+		MinNumResults:      MinResultsForTimePeriodMatching,
+		BusinessStatus:     POI.Operational,
+		UsePreciseLocation: request.UsePreciseLocation,
 	}
 
 	basicPlaces, err := matcher.Searcher.NearbySearch(ctx, placeSearchRequest)

--- a/planner/planner_APIs.go
+++ b/planner/planner_APIs.go
@@ -181,7 +181,7 @@ func (planner *MyPlanner) Destroy() {
 func (planner *MyPlanner) ReverseGeocodingHandler(context *gin.Context) {
 	latitude, _ := strconv.ParseFloat(context.Query("lat"), 64)
 	longitude, _ := strconv.ParseFloat(context.Query("lng"), 64)
-	result, err := planner.Solver.Searcher.GetMapsClient().ReverseGeocoding(context, latitude, longitude)
+	result, err := planner.Solver.Searcher.GetMapsClient().ReverseGeocode(context, latitude, longitude)
 	if err != nil {
 		log.Error(err)
 		context.JSON(http.StatusInternalServerError, err.Error())

--- a/planner/planner_APIs.go
+++ b/planner/planner_APIs.go
@@ -356,33 +356,42 @@ func (planner *MyPlanner) homePageHandler(c *gin.Context) {
 // HTTP GET API end-point handler
 // Return top planning result to user
 func (planner *MyPlanner) getPlanningApi(ctx *gin.Context) {
+	logger := iowrappers.Logger
 	var userView user.View
 	if strings.ToLower(planner.Environment) == "production" {
 		var authenticationErr error
 		userView, authenticationErr = planner.UserAuthentication(ctx, user.LevelRegular)
 		if authenticationErr != nil {
-			utils.LogErrorWithLevel(authenticationErr, utils.LogDebug)
+			logger.Debug(authenticationErr)
 			planner.login(ctx)
 			return
 		}
 	}
 
 	requestId := requestid.Get(ctx)
+
+	var err error
+	var preciseLocation bool
+	preciseLocation, err = strconv.ParseBool(ctx.DefaultQuery("precise", "false"))
+	if err != nil {
+		logger.Errorf("failed to parse Precise Location query parameter: %v", err)
+	}
+
 	location := ctx.DefaultQuery("location", "San Jose, CA, USA")
 	locationFields := strings.Split(location, ", ")
-	if err := validateLocation(location); err != nil {
+	if err = validateLocation(location, preciseLocation); err != nil {
 		ctx.String(http.StatusBadRequest, err.Error())
 		return
 	}
 
 	// date is in the format of yyyy-mm-dd
 	date := ctx.DefaultQuery("date", "")
-	if err := validateDate(date); err != nil {
+	if err = validateDate(date); err != nil {
 		ctx.String(http.StatusBadRequest, err.Error())
 		return
 	}
 
-	iowrappers.Logger.Debugf("Requested weekday is %s.", date)
+	logger.Debugf("Requested weekday is %s.", date)
 
 	numResults := ctx.DefaultQuery("numberResults", "5")
 
@@ -391,30 +400,37 @@ func (planner *MyPlanner) getPlanningApi(ctx *gin.Context) {
 		ctx.String(http.StatusBadRequest, "number of planning results of %d is invalid", numResultsInt)
 		return
 	}
-	iowrappers.Logger.Debugf("[request_id: %s] The number of requested planning results is %s.", requestId, numResults)
+	logger.Debugf("[request_id: %s] The number of requested planning results is %s.", requestId, numResults)
 
 	priceLevel := ctx.DefaultQuery("price", "2")
-	iowrappers.Logger.Debugf("Requested price range is %s", priceLevel)
+	logger.Debugf("Requested price range is %s", priceLevel)
 
 	planningReq := solution.GetStandardRequest(date, toWeekday(date), numResultsInt, toPriceLevel(priceLevel))
 	planningReq.SearchRadius = 10000 // default to 10km
-	switch len(locationFields) {
-	case 2:
-		planningReq.Location = POI.Location{City: locationFields[0], Country: locationFields[1]}
-	case 3:
-		planningReq.Location = POI.Location{City: locationFields[0], AdminAreaLevelOne: locationFields[1], Country: locationFields[2]}
-	default:
-		ctx.String(http.StatusBadRequest, "wrong location input")
-		return
+	planningReq.PreciseLocation = preciseLocation
+	logger.Debugf("use precise location: %t", preciseLocation)
+	if preciseLocation {
+		planningReq.Location = POI.Location{}
+		planningReq.Location.Longitude, _ = strconv.ParseFloat(locationFields[0], 64)
+		planningReq.Location.Latitude, _ = strconv.ParseFloat(locationFields[1], 64)
+	} else {
+		switch len(locationFields) {
+		case 2:
+			planningReq.Location = POI.Location{City: locationFields[0], Country: locationFields[1]}
+		case 3:
+			planningReq.Location = POI.Location{City: locationFields[0], AdminAreaLevelOne: locationFields[1], Country: locationFields[2]}
+		default:
+			ctx.String(http.StatusBadRequest, "wrong location input")
+			return
+		}
 	}
 
 	c := context.WithValue(ctx, iowrappers.ContextRequestIdKey, requestId)
 	planningResp := planner.Planning(c, &planningReq, userView.Username)
 
-	err := planningResp.Err
-	if err != nil {
+	if planningResp.Err != nil {
 		if planningResp.StatusCode == solution.InvalidRequestLocation {
-			ctx.String(http.StatusBadRequest, err.Error())
+			ctx.String(http.StatusBadRequest, planningResp.Err.Error())
 		} else if planningResp.StatusCode == solution.NoValidSolution {
 			errString := "No valid travel solution is found.\nPlease try searching with a larger radius or a different price level."
 			ctx.String(http.StatusBadRequest, errString)

--- a/planner/planner_APIs.go
+++ b/planner/planner_APIs.go
@@ -340,7 +340,12 @@ func (planner *MyPlanner) Planning(ctx context.Context, planningRequest *solutio
 	if len(planningRequest.Location.City) > 0 {
 		resp.TravelDestination = strings.Title(planningRequest.Location.City)
 	} else {
-		resp.TravelDestination = "Dream Vacation Destination"
+		geocodes, err := planner.Solver.Searcher.ReverseGeocode(ctx, planningRequest.Location.Latitude, planningRequest.Location.Longitude)
+		if err != nil {
+			resp.TravelDestination = "Dream Vacation Destination"
+			return
+		}
+		resp.TravelDestination = geocodes.City
 	}
 	return
 }

--- a/planner/utils.go
+++ b/planner/utils.go
@@ -37,7 +37,10 @@ func toPriceLevel(priceLevel string) POI.PriceLevel {
 }
 
 // validate location is in the format of city,country
-func validateLocation(location string) error {
+func validateLocation(location string, precise bool) error {
+	if precise {
+		return nil
+	}
 	if len(location) == 0 {
 		return errors.New("location cannot be empty")
 	}

--- a/solution/planning_solutions.go
+++ b/solution/planning_solutions.go
@@ -135,10 +135,11 @@ func GenerateSolutions(context context.Context, timeMatcher matching.Matcher, re
 		}
 
 		placesByTime, err_ := timeMatcher.Match(context, matching.Request{
-			Radius:   DefaultPlaceSearchRadius,
-			Location: request.Location,
-			Criteria: matching.FilterByTimePeriod,
-			Params:   filterParams,
+			Radius:             DefaultPlaceSearchRadius,
+			Location:           request.Location,
+			Criteria:           matching.FilterByTimePeriod,
+			Params:             filterParams,
+			UsePreciseLocation: request.PreciseLocation,
 		})
 		if err_ != nil {
 			iowrappers.Logger.Error(err_)
@@ -147,10 +148,11 @@ func GenerateSolutions(context context.Context, timeMatcher matching.Matcher, re
 		}
 
 		placesByPrice, err_ := priceRangeMatcher.Match(context, matching.Request{
-			Radius:   DefaultPlaceSearchRadius,
-			Location: request.Location,
-			Criteria: matching.FilterByPriceRange,
-			Params:   filterParams,
+			Radius:             DefaultPlaceSearchRadius,
+			Location:           request.Location,
+			Criteria:           matching.FilterByPriceRange,
+			Params:             filterParams,
+			UsePreciseLocation: request.PreciseLocation,
 		})
 		if err_ != nil {
 			iowrappers.Logger.Error(err_)

--- a/solution/solver.go
+++ b/solution/solver.go
@@ -27,13 +27,14 @@ const (
 )
 
 type PlanningRequest struct {
-	Location     POI.Location  `json:"location"`
-	Slots        []SlotRequest `json:"slots"`
-	Weekday      POI.Weekday
-	TravelDate   string
-	NumPlans     int64
-	SearchRadius uint
-	PriceLevel   POI.PriceLevel
+	Location        POI.Location  `json:"location"`
+	Slots           []SlotRequest `json:"slots"`
+	Weekday         POI.Weekday
+	TravelDate      string
+	NumPlans        int64
+	SearchRadius    uint
+	PriceLevel      POI.PriceLevel
+	PreciseLocation bool
 }
 
 type PlanningResponse struct {
@@ -87,7 +88,7 @@ func PlanningSolutionsRedisRequest(location POI.Location, placeCategories []POI.
 }
 
 func (solver *Solver) Solve(context context.Context, redisClient iowrappers.RedisClient, request *PlanningRequest, response *PlanningResponse) {
-	if !solver.ValidateLocation(context, &request.Location) {
+	if !request.PreciseLocation && !solver.ValidateLocation(context, &request.Location) {
 		response.Err = errors.New("invalid travel destination")
 		response.ErrorCode = InvalidRequestLocation
 		return

--- a/templates/login_page.html
+++ b/templates/login_page.html
@@ -67,13 +67,7 @@
             <button type="submit" class="btn btn-primary login-btn btn-block">Sign in</button>
             <!-- TODO: Add Login buttons for Social media (FB, G, TWT) as a separate PR -->
         </form>
-        <div class="d-flex justify-content-center align-items-center mt-2">
-            <div class="alert alert-primary d-none" type="alert" id="log-in-error-alert">
-                login failed, please check your credentials.
-            </div>
-        </div>
-        <!-- <a href="/v1/login-google" role="button" class="btn btn-outline-info">login with Google</a> -->
-        <div class="col s12 m6 offset-m3 center-align">
+        <div class="mt-2">
             <a class="btn btn-outline-info darken-4 white black-text" href="/v1/login-google"
                 style="text-transform:none">
                 <div class="d-flex flex-row align-items-center">
@@ -82,6 +76,10 @@
                     <span class="ms-1">Login with Google</span>
                 </div>
             </a>
+        </div>
+        <div class="mt-2 alert alert-danger alert-dismissible fade show d-none" role="alert" id="log-in-error-alert">
+            <strong>Login failed!</strong> Please check your credentials.
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
         </div>
     </div>
 

--- a/templates/search_page.html
+++ b/templates/search_page.html
@@ -51,13 +51,16 @@
             <div class="collapse navbar-collapse" id="navbar-items">
                 <ul class="nav">
                     <li class="nav-item">
-                        <a class="nav-link link-info" href="https://github.com/weihesdlegend/Vacation-Planner"><i class="fa fa-github-alt fa_custom fa-2x" style='color:#5d9ba8'></i></a>
+                        <a class="nav-link link-info" href="https://github.com/weihesdlegend/Vacation-Planner"><i
+                                class="fa fa-github-alt fa_custom fa-2x" style='color:#5d9ba8'></i></a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link link-success" href="/v1/template"><i class="fa fa-edit fa-2x" style='color:#5d9ba8'></i></a>
+                        <a class="nav-link link-success" href="/v1/template"><i class="fa fa-edit fa-2x"
+                                style='color:#5d9ba8'></i></a>
                     </li>
                     <li class="nav-item" id="signup">
-                        <a class="nav-link" href="/v1/sign-up"><i class="fa fa-user-plus fa-2x" style='color:#5d9ba8'></i> </a>
+                        <a class="nav-link" href="/v1/sign-up"><i class="fa fa-user-plus fa-2x"
+                                style='color:#5d9ba8'></i> </a>
                     </li>
                 </ul>
             </div>
@@ -111,7 +114,12 @@
     <!--forms and inputs-->
     <div class="container mt-3" style="align-items: center">
         <div class="row">
-            <div class="column">
+            <div class="col">
+                <button class="btn btn-sm btn-outline-info" id="use-precise-location">
+                    <i class="fa fa-map-marker"></i>
+                </button>
+            </div>
+            <div class="col">
                 <span class="d-inline-block float-end" data-bs-toggle="tooltip" title="Get current location">
                     <button class="btn btn-outline-info btn-sm" id="autofill">
                         <i class="fas fa-location-arrow fa-sm"></i>
@@ -121,8 +129,8 @@
         </div>
 
         <div class="row mt-1">
-            <form class="row d-flex flex-column flex-sm-row align-items-start align-items-sm-center pe-0"
-                action="/v1/plans" method="get">
+            <form class="d-flex flex-column flex-sm-row align-items-start align-items-sm-center pe-0" action="/v1/plans"
+                method="get">
                 <div class="col ps-1 pe-0 mt-1" id="dateDiv">
                     <input class="form-control border border-secondary" type="date" id="datepicker" name="date"
                         value="2020-02-29">
@@ -146,14 +154,16 @@
 
                 </div>
 
+                <input type="hidden" name="precise" value="false" id="precise-location-flag">
+
                 <div class="ps-1 pe-0 mt-1" id="priceDiv">
                     <select name="price" class="form-select border border-secondary"
                         aria-label=".form-select-sm example" id="priceToSelect" onchange="randomPriceRange(this)">
-                        <option value="0">$</option>
-                        <option value="1">$$</option>
-                        <option value="2">$$$</option>
-                        <option value="3">$$$$</option>
-                        <option value="4">Max</option>
+                        <option value="2">$$</option>
+                        <option value="3">$$$</option>
+                        <option value="4">$$$$</option>
+                        <option value="1">$</option>
+                        <option value="0">Free</option>
                         <option value="0,1,2,3,4">Surprise</option>
                         <script>
                             function randomPriceRange() {
@@ -166,6 +176,9 @@
                             }
                         </script>
                     </select>
+                </div>
+                <div class="ps-1 pe-0 mt-1">
+                    <button class="btn btn-outline-primary" type="submit">search</button>
                 </div>
             </form>
         </div>

--- a/templates/search_page.html
+++ b/templates/search_page.html
@@ -113,15 +113,17 @@
 
     <!--forms and inputs-->
     <div class="container mt-3" style="align-items: center">
-        <div class="row">
-            <div class="col">
-                <button class="btn btn-sm btn-outline-info" id="use-precise-location">
-                    <i class="fa fa-map-marker"></i>
-                </button>
+        <div class="d-flex justify-content-end">
+            <div>
+                <span data-bs-toggle="tooltip" title="Use Precise location">
+                    <button class="btn btn-sm btn-outline-info square-button" id="use-precise-location">
+                        <i class="fas fa-map-marker fa-sm"></i>
+                    </button>
+                </span>
             </div>
-            <div class="col">
-                <span class="d-inline-block float-end" data-bs-toggle="tooltip" title="Get current location">
-                    <button class="btn btn-outline-info btn-sm" id="autofill">
+            <div class="ms-1">
+                <span data-bs-toggle="tooltip" title="Get current location">
+                    <button class="btn btn-sm btn-outline-info square-button" id="autofill">
                         <i class="fas fa-location-arrow fa-sm"></i>
                     </button>
                 </span>
@@ -129,8 +131,8 @@
         </div>
 
         <div class="row mt-1">
-            <form class="d-flex flex-column flex-sm-row align-items-start align-items-sm-center pe-0" action="/v1/plans"
-                method="get">
+            <form class="row d-flex flex-column flex-sm-row align-items-start align-items-sm-center pe-0"
+                action="/v1/plans" method="get">
                 <div class="col ps-1 pe-0 mt-1" id="dateDiv">
                     <input class="form-control border border-secondary" type="date" id="datepicker" name="date"
                         value="2020-02-29">
@@ -156,7 +158,7 @@
 
                 <input type="hidden" name="precise" value="false" id="precise-location-flag">
 
-                <div class="ps-1 pe-0 mt-1" id="priceDiv">
+                <div class="col-sm-2 ps-1 pe-0 mt-1" id="priceDiv">
                     <select name="price" class="form-select border border-secondary"
                         aria-label=".form-select-sm example" id="priceToSelect" onchange="randomPriceRange(this)">
                         <option value="2">$$</option>
@@ -177,7 +179,7 @@
                         </script>
                     </select>
                 </div>
-                <div class="ps-1 pe-0 mt-1">
+                <div class="d-flex flex-row-reverse ps-1 pe-0 mt-1">
                     <button class="btn btn-outline-primary" type="submit">search</button>
                 </div>
             </form>


### PR DESCRIPTION
## Description
For metropolitan areas, using the current location often resolves to the downtown areas. We provide an option for users to use their exact current location for searching nearby places.

## Solution
Add a button in the search page for this new option.

The trickier part for the backend change is how to use cache properly. Redis is using lat/long for searching places. Therefore we need to feed the Redis client with precise location. At the same time, we need to maintain data freshness, therefore we need to reverse geocoding in order to find the city-level info in order to determine when to perform a new search.

## Testing
Did you add any new test for this change, performed manual integration tests, or both?


## Final Checks
- [x] Have you removed commented code ?
- [x] Have you used gofmt to format your code ?
- [ ] You have added unit tests
