### PR TITLE
Fix: Insensitive to user email for login and signup

### DIFF
--- a/iowrappers/maps_client.go
+++ b/iowrappers/maps_client.go
@@ -15,9 +15,9 @@ import (
 
 // SearchClient defines an interface of a client that performs location-based operations such as nearby search
 type SearchClient interface {
-	Geocode(context.Context, *GeocodeQuery) (float64, float64, error)       // translate a textual location to latitude and longitude
+	Geocode(context.Context, *GeocodeQuery) (float64, float64, error)        // translate a textual location to latitude and longitude
 	ReverseGeocode(context.Context, float64, float64) (*GeocodeQuery, error) // look up a textual location based on latitude and longitude
-	NearbySearch(context.Context, *PlaceSearchRequest) ([]POI.Place, error) // search nearby places in a category around a central location
+	NearbySearch(context.Context, *PlaceSearchRequest) ([]POI.Place, error)  // search nearby places in a category around a central location
 }
 
 type MapsClient struct {


### PR DESCRIPTION
## Description
The authentication system do not treat user emails case-insensitive.

## Solution
* Save email addresses in lower case when users create accounts
* Check lower case converted email addresses when authenticating users.

Expected behaviors:
* When users log in with usernames, differentiate cases.
* When users log in with emails, do NOT differentiate cases.
* When users sign up they cannot use emails of same lower-cased form.

## Testing
- [ ] Integration testing on Heroku staging
- [ ] Added new unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
