### PR TITLE
[Fix] Correct the order of top plans returned from search

### DIFF
--- a/solution/planning_solutions.go
+++ b/solution/planning_solutions.go
@@ -4,8 +4,9 @@ import (
 	"container/heap"
 	"context"
 	"errors"
-	log "github.com/sirupsen/logrus"
 	"strings"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/google/uuid"
 	"github.com/yourbasic/radix"
@@ -113,8 +114,15 @@ func FindBestPlanningSolutions(placeClusters [][]matching.Place, topSolutionsCou
 		top := heap.Pop(priorityQueue).(graph.Vertex)
 		res = append(res, top.Object.(PlanningSolution))
 	}
+	// min-heap, res needs to be reversed to get the descending order
+	return reversePlans(res)
+}
 
-	return res
+func reversePlans(plans []PlanningSolution) []PlanningSolution {
+	for i, j := 0, len(plans)-1; i < j; i, j = i+1, j-1 {
+		plans[i], plans[j] = plans[j], plans[i]
+	}
+	return plans
 }
 
 func GenerateSolutions(context context.Context, timeMatcher matching.Matcher, redisClient iowrappers.RedisClient, redisRequest iowrappers.PlanningSolutionsCacheRequest, request PlanningRequest, priceRangeMatcher matching.Matcher) (solutions []PlanningSolution, solutionRedisKey string, err error) {

--- a/test/solution_candidate_selection_test.go
+++ b/test/solution_candidate_selection_test.go
@@ -1,11 +1,12 @@
 package test
 
 import (
+	"strconv"
+	"testing"
+
 	"github.com/weihesdlegend/Vacation-planner/POI"
 	"github.com/weihesdlegend/Vacation-planner/matching"
 	"github.com/weihesdlegend/Vacation-planner/solution"
-	"strconv"
-	"testing"
 )
 
 // test if priority queue gives top solution candidates
@@ -33,7 +34,7 @@ func TestSolutionCandidateSelection(t *testing.T) {
 		return
 	}
 
-	expectation := []float64{94, 95, 96, 97, 98}
+	expectation := []float64{98, 97, 96, 95, 94}
 	for idx, r := range res {
 		if r.Score != expectation[idx] {
 			t.Errorf("expected %f, got %f", expectation[idx], r.Score)


### PR DESCRIPTION
## Description
Bug was found when examining scores of top plans, and the current top plans are shown in a reverse order their plan scores. 

## Solution
The bug is due to the usage of min-heap. The result list is in ascending order instead of descending order. A simple fix is to reverse the output plan list.

## Testing
- [ ] Integration testing on Heroku staging
- [ ] Added new unit tests
- [x] Fixed broken unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
