### PR TITLE
Fix: persist location input value when going back to the search page

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,6 +1,5 @@
 // methods for the search page
-import { locateMe, setDateToday, preciseLocation } from "./utils.js";
-
+import { locateMe, preciseLocation, setDateToday } from "./utils.js";
 import { logOut } from "./user.js";
 
 setDateToday();
@@ -30,16 +29,27 @@ setDateToday();
     )
 })(jQuery);
 
-$(document).ready(function CheckPreviousLocation() {
-  const elem = document.getElementById("location");
-  if (sessionStorage.getItem("locationPerm")) {
-    console.log(
-      `Set the Location based on PageLoad...` +
-        sessionStorage.getItem("locationPerm")
-    );
-    elem.value = sessionStorage.getItem("locationPerm");
-  }
+document.getElementById("logout-confirm-btn").addEventListener(
+    "click", logOut
+)
+
+const FORM = document.getElementById("main-form");
+const STORAGE_ITEM = "location";
+const LOCATION_INPUT = document.getElementById("location");
+$(document).ready(() => {
+    const val = sessionStorage.getItem(STORAGE_ITEM);
+    if (val) {
+        console.log(`Set the Location based on PageLoad...` + val);
+        LOCATION_INPUT.value = val;
+    }
 });
+
+FORM.addEventListener('submit', () => {
+    if (LOCATION_INPUT.value) {
+        sessionStorage.setItem(STORAGE_ITEM, LOCATION_INPUT.value);
+        console.log(`The location is ${LOCATION_INPUT.value}`);
+    }
+})
 
 document.querySelector('#autofill').addEventListener('click', locateMe);
 

--- a/templates/search_page.html
+++ b/templates/search_page.html
@@ -132,7 +132,7 @@
 
         <div class="row mt-1">
             <form class="row d-flex flex-column flex-sm-row align-items-start align-items-sm-center pe-0"
-                action="/v1/plans" method="get">
+                action="/v1/plans" method="get" id="main-form">
                 <div class="col ps-1 pe-0 mt-1" id="dateDiv">
                     <input class="form-control border border-secondary" type="date" id="datepicker" name="date"
                         value="2020-02-29">
@@ -146,18 +146,8 @@
 
                     <div class="flex-fill">
                         <input class="form-control border-0" type="search" id="location" placeholder="Search"
-                            aria-label="Search" name="location" value="Los Angeles, CA, USA"
-                            onchange="fetchLocation(this)">
+                            aria-label="Search" name="location" value="Los Angeles, CA, USA">
                     </div>
-                    <script>
-                        function fetchLocation() {
-                            const loc = document.getElementById("location");
-                            if (loc) {
-                                sessionStorage.setItem("locationPerm", loc.value);
-                                console.log(`The location is ${loc.value}`);
-                            }
-                        }
-                    </script>
                     <div class="fixedwidthicon">
                         <span id="searchSpinner" class="spinner-border spinner-border-sm text-info mx-1 visually-hidden"
                             role="status" aria-hidden="true"></span>


### PR DESCRIPTION
Also restore log-out function on the search page.

## Description
Setting location on change does not guarantee consistent location persistence behavior.

## Solution
* Set location in `SessionStorage` only when the form is submitted.
* Restore log out functionality.

## Testing
- [ ] Integration testing on Heroku staging
- [ ] Added new unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
