### PR TITLE
Fix: Redis plan search does not work with precise location

### DIFF
--- a/iowrappers/redis_client.go
+++ b/iowrappers/redis_client.go
@@ -469,6 +469,7 @@ func (redisClient *RedisClient) SavePlanningSolutions(context context.Context, r
 }
 
 func (redisClient *RedisClient) PlanningSolutions(context context.Context, request PlanningSolutionsCacheRequest) (PlanningSolutionsResponse, error) {
+	Logger.Debugf("->RedisClient.PlanningSolutions(%v)", request)
 	var response PlanningSolutionsResponse
 	redisListKey, keyGenerationErr := generateTravelPlansCacheKey(request)
 	if keyGenerationErr != nil {


### PR DESCRIPTION
## Description
Use precise location feature does not behave consistently. Only fresh searches return correct results. Some debugging work shows that the issue lies in Redis plan search uses city, country location, which is not available when using precise location feature.

## Solution
* Make sure to perform reverse geocoding before sending request to Redis

## Testing
- [x] Integration testing on Heroku staging
- [ ] Added new unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
