### PR TITLE
Add brand keyword search and POST /v1/nearby-places endpoint

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,27 +11,28 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
-          go-version: ^1.23
-      - uses: actions/checkout@v3
+          go-version-file: go.mod
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v9
         with:
           version: latest
+          only-new-issues: true
 
   build:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v3
-        with:
-          go-version: ^1.23
-        id: go
-
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
+
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+        id: go
 
       - name: Get dependencies
         run: |

--- a/POI/categories.go
+++ b/POI/categories.go
@@ -23,6 +23,8 @@ const (
 type LocationType string
 
 const (
+	// LocationTypeAny leaves the Google Maps place type unset, used by keyword (brand) searches
+	LocationTypeAny           = LocationType("")
 	LocationTypeCafe          = LocationType("cafe")
 	LocationTypeRestaurant    = LocationType("restaurant")
 	LocationTypeMuseum        = LocationType("museum")
@@ -70,6 +72,31 @@ func EncodeNearbySearchRedisKey(placeCategory PlaceCategory, level PriceLevel) s
 		keys = append(keys, fmt.Sprintf("level%d", level))
 	}
 	return strings.Join(keys, ":")
+}
+
+// NormalizeBrandKey converts a brand keyword into a stable slug used in Redis keys and
+// name matching, e.g. "Dunkin' Donuts" -> "dunkin-donuts"
+func NormalizeBrandKey(keyword string) string {
+	var b strings.Builder
+	pendingDash := false
+	for _, r := range strings.ToLower(strings.TrimSpace(keyword)) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			if pendingDash && b.Len() > 0 {
+				b.WriteRune('-')
+			}
+			b.WriteRune(r)
+			pendingDash = false
+		} else {
+			pendingDash = true
+		}
+	}
+	return b.String()
+}
+
+// EncodeBrandNearbySearchRedisKey generates a Redis key for brand-scoped nearby search,
+// keeping brand search results in buckets separate from category-based searches
+func EncodeBrandNearbySearchRedisKey(keyword string) string {
+	return strings.Join([]string{"placeIDs", "brand", NormalizeBrandKey(keyword)}, ":")
 }
 
 type StayingTime uint8

--- a/POI/places.go
+++ b/POI/places.go
@@ -43,6 +43,11 @@ func (w Weekday) Name() string {
 	return mapping[w]
 }
 
+// WeekdayFromTime converts Go's time.Weekday (Sunday=0) to POI's Weekday (Monday=0)
+func WeekdayFromTime(day time.Weekday) Weekday {
+	return Weekday((int(day) + 6) % 7)
+}
+
 type PlacePhoto struct {
 	// reference from Google Images
 	Reference string `bson:"reference"`
@@ -146,6 +151,13 @@ func (place *Place) GetStatus() BusinessStatus {
 
 func (place *Place) GetHour(day Weekday) string {
 	return place.Hours[day]
+}
+
+// KnownClosedOnDay reports whether the place's cached hours explicitly mark it closed on
+// the given weekday, e.g. "Sunday: Closed". Places with unknown or default hours return
+// false — absence of data is not treated as closed.
+func (place *Place) KnownClosedOnDay(day Weekday) bool {
+	return strings.Contains(strings.ToLower(place.GetHour(day)), "closed")
 }
 
 func (place *Place) GetID() string {

--- a/iowrappers/nearby_search.go
+++ b/iowrappers/nearby_search.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -48,6 +49,10 @@ type PlaceSearchRequest struct {
 	// StrictNameMatch only keeps results whose names match Keyword (after normalization).
 	// It applies before results are cached so brand-scoped Redis buckets stay brand-pure.
 	StrictNameMatch bool
+
+	// DetailsLimit caps how many places get the expensive Place Details API call, chosen
+	// by proximity to the request location. Zero means no cap (previous behavior).
+	DetailsLimit int
 }
 
 // MatchesBrandName reports whether a place name matches a brand keyword after normalization,
@@ -136,6 +141,7 @@ func (c *MapsClient) extensiveNearbySearch(ctx context.Context, maxRequestTimes 
 
 	var err error
 	var mapsFailuresCount uint = 0
+	detailsBudget := request.DetailsLimit // remaining Place Details calls across all pages; only enforced when DetailsLimit > 0
 outer:
 	for totalPlaceCount < request.MinNumResults {
 		reqTimes++
@@ -163,12 +169,7 @@ outer:
 			// places for Google Maps place details search (https://developers.google.com/maps/documentation/places/web-service/details)
 			// the original purpose of doing a details search is getting opening hours info
 			// later on we added more fields of interest as specified in the config/config.yaml file
-			placeIdMap := make(map[int]string)
-			for k, res := range searchResp.Results {
-				if res.OpeningHours == nil || res.OpeningHours.WeekdayText == nil {
-					placeIdMap[k] = res.PlaceID
-				}
-			}
+			placeIdMap := selectPlacesForDetails(request, &searchResp, &detailsBudget)
 
 			// placeholder for filtering places that do no need updates
 			placesToUpdate := set.Of[string]{}
@@ -203,6 +204,44 @@ outer:
 		"total processing time", time.Since(searchStartTime),
 	)
 	done <- true
+}
+
+// selectPlacesForDetails picks the search results worth a Place Details API call: places
+// missing opening hours, excluding results a strict brand-name match would later drop
+// (details on those are wasted spend), and — when the request sets DetailsLimit — capped
+// to the remaining budget by proximity to the request location.
+func selectPlacesForDetails(request *PlaceSearchRequest, searchResp *maps.PlacesSearchResponse, detailsBudget *int) map[int]string {
+	type candidate struct {
+		idx  int
+		dist float64
+	}
+	candidates := make([]candidate, 0, len(searchResp.Results))
+	for k, res := range searchResp.Results {
+		if res.OpeningHours != nil && res.OpeningHours.WeekdayText != nil {
+			continue
+		}
+		if request.Keyword != "" && request.StrictNameMatch && !MatchesBrandName(res.Name, request.Keyword) {
+			continue
+		}
+		dist := utils.HaversineDist(
+			[]float64{request.Location.Latitude, request.Location.Longitude},
+			[]float64{res.Geometry.Location.Lat, res.Geometry.Location.Lng})
+		candidates = append(candidates, candidate{idx: k, dist: dist})
+	}
+
+	if request.DetailsLimit > 0 {
+		sort.Slice(candidates, func(i, j int) bool { return candidates[i].dist < candidates[j].dist })
+		if len(candidates) > *detailsBudget {
+			candidates = candidates[:*detailsBudget]
+		}
+		*detailsBudget -= len(candidates)
+	}
+
+	placeIdMap := make(map[int]string)
+	for _, cand := range candidates {
+		placeIdMap[cand.idx] = searchResp.Results[cand.idx].PlaceID
+	}
+	return placeIdMap
 }
 
 func (c *MapsClient) searchPlaceDetails(

--- a/iowrappers/nearby_search.go
+++ b/iowrappers/nearby_search.go
@@ -39,6 +39,25 @@ type PlaceSearchRequest struct {
 	UsePreciseLocation bool
 
 	PriceLevel POI.PriceLevel
+
+	// Keyword is a brand or merchant keyword (e.g. "Dunkin'"). When set, the search is
+	// keyword-based instead of place-type-based, and results are cached under a
+	// brand-scoped Redis key (see POI.EncodeBrandNearbySearchRedisKey).
+	Keyword string
+
+	// StrictNameMatch only keeps results whose names match Keyword (after normalization).
+	// It applies before results are cached so brand-scoped Redis buckets stay brand-pure.
+	StrictNameMatch bool
+}
+
+// MatchesBrandName reports whether a place name matches a brand keyword after normalization,
+// e.g. "Dunkin' Donuts #1234" matches keyword "Dunkin'"
+func MatchesBrandName(placeName, keyword string) bool {
+	normalizedKeyword := POI.NormalizeBrandKey(keyword)
+	if normalizedKeyword == "" {
+		return false
+	}
+	return strings.Contains(POI.NormalizeBrandKey(placeName), normalizedKeyword)
 }
 
 // CreateMapSearchRequest creates a NearbySearchRequest for maps NearbySearch, adjust key settings such as radius and price levels
@@ -59,6 +78,7 @@ func CreateMapSearchRequest(reqIn *PlaceSearchRequest, placeType POI.LocationTyp
 			Lat: reqIn.Location.Latitude,
 			Lng: reqIn.Location.Longitude,
 		},
+		Keyword:   reqIn.Keyword,
 		Radius:    radius,
 		PageToken: token,
 		RankBy:    maps.RankBy("prominence"),
@@ -92,6 +112,11 @@ func (c *MapsClient) NearbySearch(ctx context.Context, request *PlaceSearchReque
 func (c *MapsClient) extensiveNearbySearch(ctx context.Context, maxRequestTimes uint, request *PlaceSearchRequest, places *[]POI.Place, done chan bool) {
 	searchStartTime := time.Now()
 	placeTypes := POI.GetPlaceTypes(request.PlaceCat) // get place types in a category
+	if request.Keyword != "" {
+		// keyword (brand) searches leave the place type unset so Google Maps matches the
+		// keyword across all place types in a single search
+		placeTypes = []POI.LocationType{POI.LocationTypeAny}
+	}
 
 	nextPageTokenMap := make(map[POI.LocationType]string) // map of place types to search token
 	placeCountPerPlaceType := make(map[POI.LocationType]int)

--- a/iowrappers/nearby_search.go
+++ b/iowrappers/nearby_search.go
@@ -255,14 +255,23 @@ func (c *MapsClient) searchPlaceDetails(
 	detailsSearchResults := make([]PlaceDetailsSearchResult, len(placeIdMap))
 	var wg sync.WaitGroup
 	wg.Add(len(placeIdMap))
+	// placeIdMap keys are indices into searchResp.Results and may be sparse (e.g. when a
+	// details budget filters candidates), so each goroutine gets its own compact slot and
+	// records the result index in PlaceDetailsSearchResult.idx
+	slot := 0
 	for idx, placeId := range placeIdMap {
-		go PlaceDetailsSearchWrapper(ctx, c, idx, placeId, c.DetailedSearchFields, &detailsSearchResults[idx], &wg, placesToUpdate)
+		go PlaceDetailsSearchWrapper(ctx, c, idx, placeId, c.DetailedSearchFields, &detailsSearchResults[slot], &wg, placesToUpdate)
+		slot++
 	}
 	wg.Wait()
 	searchDuration := time.Since(singlePlaceTypeSearchStartTime)
 
 	// fill fields from detail search results to nearby search results
 	for _, placeDetails := range detailsSearchResults {
+		if placeDetails.res == nil {
+			// the details lookup failed or was skipped; leave the nearby-search data as is
+			continue
+		}
 		idx := placeDetails.idx
 		placeId := searchResp.Results[idx].PlaceID
 		if !placesToUpdate.Has(placeId) {

--- a/iowrappers/nearby_search_test.go
+++ b/iowrappers/nearby_search_test.go
@@ -1,0 +1,72 @@
+package iowrappers
+
+import (
+	"testing"
+
+	"github.com/weihesdlegend/Vacation-planner/POI"
+	"googlemaps.github.io/maps"
+)
+
+func TestSelectPlacesForDetails(t *testing.T) {
+	requestLocation := POI.Location{Latitude: 40.7484, Longitude: -73.9857}
+	resp := &maps.PlacesSearchResponse{
+		Results: []maps.PlacesSearchResult{
+			{ // 0: has hours already, never needs details
+				Name:         "Dunkin'",
+				PlaceID:      "has-hours",
+				Geometry:     maps.AddressGeometry{Location: maps.LatLng{Lat: 40.7485, Lng: -73.9858}},
+				OpeningHours: &maps.OpeningHours{WeekdayText: []string{"Monday: 6AM-9PM"}},
+			},
+			{ // 1: name does not match the brand, details would be wasted spend
+				Name:     "Dunham's Sports",
+				PlaceID:  "wrong-brand",
+				Geometry: maps.AddressGeometry{Location: maps.LatLng{Lat: 40.7486, Lng: -73.9859}},
+			},
+			{ // 2: matching brand, far from the request location
+				Name:     "Dunkin' Donuts",
+				PlaceID:  "far",
+				Geometry: maps.AddressGeometry{Location: maps.LatLng{Lat: 40.8000, Lng: -73.9500}},
+			},
+			{ // 3: matching brand, nearest candidate
+				Name:     "Dunkin'",
+				PlaceID:  "near",
+				Geometry: maps.AddressGeometry{Location: maps.LatLng{Lat: 40.7490, Lng: -73.9860}},
+			},
+		},
+	}
+
+	request := &PlaceSearchRequest{
+		Keyword:         "Dunkin'",
+		StrictNameMatch: true,
+		Location:        requestLocation,
+		DetailsLimit:    1,
+	}
+	budget := request.DetailsLimit
+
+	placeIdMap := selectPlacesForDetails(request, resp, &budget)
+
+	if len(placeIdMap) != 1 {
+		t.Fatalf("expect 1 place selected for details, got %d: %v", len(placeIdMap), placeIdMap)
+	}
+	if placeIdMap[3] != "near" {
+		t.Errorf("expect the nearest matching place (index 3, id 'near') to be selected, got %v", placeIdMap)
+	}
+	if budget != 0 {
+		t.Errorf("expect details budget to be exhausted, got %d", budget)
+	}
+
+	// budget exhausted: subsequent pages select nothing
+	nextPage := selectPlacesForDetails(request, resp, &budget)
+	if len(nextPage) != 0 {
+		t.Errorf("expect no selections once the budget is exhausted, got %v", nextPage)
+	}
+
+	// no cap: everything missing hours that matches the brand is selected, keyed by
+	// (possibly sparse) result index
+	uncapped := &PlaceSearchRequest{Keyword: "Dunkin'", StrictNameMatch: true, Location: requestLocation}
+	unlimited := 0
+	all := selectPlacesForDetails(uncapped, resp, &unlimited)
+	if len(all) != 2 || all[2] != "far" || all[3] != "near" {
+		t.Errorf("expect indices 2 and 3 selected without a cap, got %v", all)
+	}
+}

--- a/iowrappers/poi_searcher.go
+++ b/iowrappers/poi_searcher.go
@@ -154,7 +154,13 @@ func (s *PoiSearcher) NearbySearch(context context.Context, request *PlaceSearch
 	Logger.Debugf("(PoiSearcher)NearbySearch: [request_id: %s] the number of results from redis is %d", context.Value(ContextRequestIdKey), len(savedPlaces))
 
 	// update last search time for the city
-	lastSearchTime, lastSearchTimeMiss := s.redisClient.GetMapsLastSearchTime(context, location, request.PlaceCat, request.PriceLevel)
+	var lastSearchTime time.Time
+	var lastSearchTimeMiss error
+	if request.Keyword != "" {
+		lastSearchTime, lastSearchTimeMiss = s.redisClient.GetBrandMapsLastSearchTime(context, location, request.Keyword)
+	} else {
+		lastSearchTime, lastSearchTimeMiss = s.redisClient.GetMapsLastSearchTime(context, location, request.PlaceCat, request.PriceLevel)
+	}
 
 	currentTime := time.Now()
 
@@ -163,16 +169,21 @@ func (s *PoiSearcher) NearbySearch(context context.Context, request *PlaceSearch
 	}
 	// use place data from the database if it is fresh and at least one saved place satisfies the request
 	if isSavedPlacesFresh() && placesErr == nil && len(savedPlaces) > 0 {
-		Logger.Infof("(PoiSearcher)NearbySearch: [request_id: %s] Using Redis to fulfill request for location %+v with category %s and price level %d",
+		Logger.Infof("(PoiSearcher)NearbySearch: [request_id: %s] Using Redis to fulfill request for location %+v with category %s, keyword %q and price level %d",
 			context.Value(ContextRequestIdKey),
 			request.Location,
 			request.PlaceCat,
+			request.Keyword,
 			request.PriceLevel)
 		places = append(places, savedPlaces...)
 		return places, nil
 	}
 
-	utils.LogErrorWithLevel(s.redisClient.SetMapsLastSearchTime(context, location, request.PlaceCat, request.PriceLevel, currentTime.Format(time.RFC3339)), utils.LogError)
+	if request.Keyword != "" {
+		utils.LogErrorWithLevel(s.redisClient.SetBrandMapsLastSearchTime(context, location, request.Keyword, currentTime.Format(time.RFC3339)), utils.LogError)
+	} else {
+		utils.LogErrorWithLevel(s.redisClient.SetMapsLastSearchTime(context, location, request.PlaceCat, request.PriceLevel, currentTime.Format(time.RFC3339)), utils.LogError)
+	}
 
 	// initiate a new external search
 	newPlaces, searchErr := s.searchPlacesWithMaps(context, request)
@@ -180,10 +191,21 @@ func (s *PoiSearcher) NearbySearch(context context.Context, request *PlaceSearch
 		return nil, searchErr
 	}
 
+	if request.Keyword != "" && request.StrictNameMatch {
+		// drop keyword-search results that are merely related to the brand (Google Maps
+		// matches keywords against reviews and other content, not just names) before they
+		// reach the brand-scoped cache
+		newPlaces = Filter(newPlaces, func(place POI.Place) bool { return MatchesBrandName(place.Name, request.Keyword) })
+	}
+
 	// safeguard on accessing elements in a nil slice
 	if len(newPlaces) > 0 {
 		// update Redis with all the new places obtained
-		s.UpdateRedis(context, newPlaces)
+		if request.Keyword != "" {
+			s.redisClient.SetPlacesAddGeoLocationsForBrand(context, request.Keyword, newPlaces)
+		} else {
+			s.UpdateRedis(context, newPlaces)
+		}
 
 		// include places from cache in the result
 		places = append(places, newPlaces...)
@@ -195,6 +217,11 @@ func (s *PoiSearcher) NearbySearch(context context.Context, request *PlaceSearch
 // processLocation performs reverse geocoding for precise location to find city-level information and performs geocoding to find precise latitude and longitude values
 func (s *PoiSearcher) processLocation(ctx context.Context, req *PlaceSearchRequest) error {
 	location := &req.Location
+	// the location is already fully resolved (precise coordinates plus city-level info);
+	// callers fanning out multiple searches around one coordinate resolve it once up front
+	if !req.UsePreciseLocation && location.City != "" && (location.Latitude != 0 || location.Longitude != 0) {
+		return nil
+	}
 	if req.UsePreciseLocation {
 		Logger.Debugf("->NearbySearch: using precise location")
 		geoQuery, err := s.GetMapsClient().ReverseGeocode(ctx, req.Location.Latitude, req.Location.Longitude)

--- a/iowrappers/poi_searcher.go
+++ b/iowrappers/poi_searcher.go
@@ -18,7 +18,8 @@ import (
 type ContextKey string
 
 const (
-	MaxSearchRadius              = 16000               // 10 miles
+	MaxSearchRadius              = 16000               // 10 miles, upper bound for radius requested by callers
+	ColdStartSearchRadius        = 8000                // 5 miles, radius used for external maps searches that populate the cache
 	MinMapsResultRefreshDuration = time.Hour * 24 * 14 // 14 days
 	GoogleSearchHomePageURL      = "https://www.google.com/"
 	ContextRequestIdKey          = ContextKey("request_id")
@@ -250,8 +251,9 @@ func (s *PoiSearcher) processLocation(ctx context.Context, req *PlaceSearchReque
 func (s *PoiSearcher) searchPlacesWithMaps(ctx context.Context, req *PlaceSearchRequest) ([]POI.Place, error) {
 	originalRadius := req.Radius
 
-	// use a large search radius whenever we call external maps services
-	req.Radius = MaxSearchRadius
+	// use a larger-than-requested search radius whenever we call external maps services,
+	// so one API spend populates the cache for a whole area
+	req.Radius = ColdStartSearchRadius
 
 	places, err := s.GetMapsClient().NearbySearch(ctx, req)
 

--- a/iowrappers/redis_client.go
+++ b/iowrappers/redis_client.go
@@ -245,6 +245,64 @@ func (r *RedisClient) SetPlacesAddGeoLocations(c context.Context, places []POI.P
 	wg.Wait()
 }
 
+// SetPlacesAddGeoLocationsForBrand stores place details and adds places to a brand-scoped
+// geo index (placeIDs:brand:{brandKey}) so cached brand searches stay brand-pure.
+// Brand result sets are small, so a single pipeline is used without batching.
+func (r *RedisClient) SetPlacesAddGeoLocationsForBrand(c context.Context, keyword string, places []POI.Place) {
+	if len(places) == 0 || keyword == "" {
+		return
+	}
+
+	redisKey := POI.EncodeBrandNearbySearchRedisKey(keyword)
+	_, err := r.Get().Pipelined(c, func(pipe redis.Pipeliner) error {
+		for _, place := range places {
+			geoLocation := &redis.GeoLocation{
+				Name:      place.ID,
+				Latitude:  place.GetLocation().Latitude,
+				Longitude: place.GetLocation().Longitude,
+			}
+			pipe.GeoAdd(c, redisKey, geoLocation)
+
+			json_, err := json.Marshal(place)
+			if err != nil {
+				Logger.Error(err)
+				continue
+			}
+			pipe.Set(c, PlaceDetailsRedisKeyPrefix+place.ID, json_, 0)
+		}
+		return nil
+	})
+	if err != nil {
+		Logger.Error(err)
+	}
+}
+
+func brandLastSearchTimeRedisField(location POI.Location, keyword string) string {
+	return strings.ToLower(strings.Join([]string{location.Country, location.AdminAreaLevelOne, location.City, "brand", POI.NormalizeBrandKey(keyword)}, ":"))
+}
+
+// GetBrandMapsLastSearchTime returns the last time an external maps search ran for a brand keyword in a city
+func (r *RedisClient) GetBrandMapsLastSearchTime(context context.Context, location POI.Location, keyword string) (lastSearchTime time.Time, err error) {
+	lst, cacheErr := r.client.HGet(context, MapsLastSearchTimeRedisKey, brandLastSearchTimeRedisField(location, keyword)).Result()
+	if cacheErr != nil {
+		err = cacheErr
+		return
+	}
+
+	parsedLastSearchTime, timeParsingErr := time.Parse(time.RFC3339, lst)
+	if timeParsingErr != nil {
+		utils.LogErrorWithLevel(timeParsingErr, utils.LogError)
+	}
+	lastSearchTime = parsedLastSearchTime
+	return
+}
+
+// SetBrandMapsLastSearchTime records the last time an external maps search ran for a brand keyword in a city
+func (r *RedisClient) SetBrandMapsLastSearchTime(context context.Context, location POI.Location, keyword string, requestTime string) (err error) {
+	_, err = r.client.HSet(context, MapsLastSearchTimeRedisKey, brandLastSearchTimeRedisField(location, keyword), requestTime).Result()
+	return
+}
+
 func (r *RedisClient) UpdatePlace(ctx context.Context, id string, data map[string]interface{}) error {
 	var p POI.Place
 	err := r.FetchSingleRecord(ctx, PlaceDetailsRedisKeyPrefix+id, &p)
@@ -387,6 +445,9 @@ func (r *RedisClient) getPlace(context context.Context, placeId string) (place P
 
 func (r *RedisClient) NearbySearch(ctx context.Context, req *PlaceSearchRequest) ([]POI.Place, error) {
 	redisKey := POI.EncodeNearbySearchRedisKey(req.PlaceCat, req.PriceLevel)
+	if req.Keyword != "" {
+		redisKey = POI.EncodeBrandNearbySearchRedisKey(req.Keyword)
+	}
 	requestLat, requestLng := req.Location.Latitude, req.Location.Longitude
 	searchRadius := req.Radius
 

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -1173,6 +1173,10 @@ type nearbyPlacesRequest struct {
 	Radius uint `json:"radius"`
 	// maximum number of places returned per brand
 	Limit int `json:"limit"`
+	// optional RFC3339 timestamp representing local time at the searched location
+	// (e.g. "2026-07-21T13:00:00-07:00"); places whose hours mark them closed on that
+	// weekday are excluded. Defaults to server time when empty.
+	LocalTime string `json:"localTime"`
 }
 
 type nearbyPlacesBrandResult struct {
@@ -1201,6 +1205,15 @@ func (p *MyPlanner) getNearbyPlaces(ctx *gin.Context) {
 	limit := req.Limit
 	if limit <= 0 || limit > 20 {
 		limit = 5
+	}
+	day := POI.WeekdayFromTime(time.Now().Weekday())
+	if req.LocalTime != "" {
+		localTime, parseErr := time.Parse(time.RFC3339, req.LocalTime)
+		if parseErr != nil {
+			ctx.JSON(http.StatusBadRequest, gin.H{"error": "localTime must be an RFC3339 timestamp"})
+			return
+		}
+		day = POI.WeekdayFromTime(localTime.Weekday())
 	}
 
 	requestId := requestid.Get(ctx)
@@ -1237,6 +1250,8 @@ func (p *MyPlanner) getNearbyPlaces(ctx *gin.Context) {
 			if searchErr != nil {
 				result.Error = searchErr.Error()
 			} else if len(places) > 0 {
+				// drop places explicitly marked closed on the requested day
+				places = iowrappers.Filter(places, func(place POI.Place) bool { return !place.KnownClosedOnDay(day) })
 				// Redis results are sorted by distance ascending; keep the nearest ones
 				if len(places) > limit {
 					places = places[:limit]

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -1229,6 +1229,7 @@ func (p *MyPlanner) getNearbyPlaces(ctx *gin.Context) {
 				Location:        location,
 				Radius:          radius,
 				MinNumResults:   uint(limit),
+				DetailsLimit:    limit,
 				BusinessStatus:  POI.Operational,
 			}
 			result := nearbyPlacesBrandResult{Brand: keyword, Places: []POI.Place{}}

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -1235,7 +1235,7 @@ func (p *MyPlanner) getNearbyPlaces(ctx *gin.Context) {
 			places, searchErr := p.Solver.Searcher.NearbySearch(searchContext, searchReq)
 			if searchErr != nil {
 				result.Error = searchErr.Error()
-			} else {
+			} else if len(places) > 0 {
 				// Redis results are sorted by distance ascending; keep the nearest ones
 				if len(places) > limit {
 					places = places[:limit]

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -1165,6 +1165,91 @@ func (p *MyPlanner) getNearbyCities(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, gin.H{"cities": resp.Cities})
 }
 
+type nearbyPlacesRequest struct {
+	// brand or merchant keywords to search for, e.g. ["Dunkin'", "Saks Fifth Avenue"]
+	Brands   []string     `json:"brands" binding:"required,min=1,max=25"`
+	Location POI.Location `json:"location"`
+	// search radius in meters; defaults to the maximum search radius when zero
+	Radius uint `json:"radius"`
+	// maximum number of places returned per brand
+	Limit int `json:"limit"`
+}
+
+type nearbyPlacesBrandResult struct {
+	Brand  string      `json:"brand"`
+	Places []POI.Place `json:"places"`
+	Error  string      `json:"error,omitempty"`
+}
+
+// getNearbyPlaces returns operational places for each requested brand keyword around a coordinate.
+// Results are served from the brand-scoped Redis geo index when fresh, falling back to Google Maps.
+func (p *MyPlanner) getNearbyPlaces(ctx *gin.Context) {
+	req := &nearbyPlacesRequest{}
+	if err := ctx.ShouldBindJSON(req); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if req.Location.Latitude == 0 && req.Location.Longitude == 0 {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "location with latitude and longitude is required"})
+		return
+	}
+
+	radius := req.Radius
+	if radius == 0 || radius > iowrappers.MaxSearchRadius {
+		radius = iowrappers.MaxSearchRadius
+	}
+	limit := req.Limit
+	if limit <= 0 || limit > 20 {
+		limit = 5
+	}
+
+	requestId := requestid.Get(ctx)
+	searchContext := context.WithValue(ctx.Request.Context(), iowrappers.ContextRequestIdKey, requestId)
+
+	// resolve city-level info once so the per-brand searches skip geocoding
+	geoQuery, err := p.Solver.Searcher.ReverseGeocode(searchContext, req.Location.Latitude, req.Location.Longitude)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	location := req.Location
+	location.City = geoQuery.City
+	location.AdminAreaLevelOne = geoQuery.AdminAreaLevelOne
+	location.Country = geoQuery.Country
+
+	results := make([]nearbyPlacesBrandResult, len(req.Brands))
+	wg := &sync.WaitGroup{}
+	wg.Add(len(req.Brands))
+	for i, brand := range req.Brands {
+		go func(idx int, keyword string) {
+			defer wg.Done()
+			searchReq := &iowrappers.PlaceSearchRequest{
+				Keyword:         keyword,
+				StrictNameMatch: true,
+				Location:        location,
+				Radius:          radius,
+				MinNumResults:   uint(limit),
+				BusinessStatus:  POI.Operational,
+			}
+			result := nearbyPlacesBrandResult{Brand: keyword, Places: []POI.Place{}}
+			places, searchErr := p.Solver.Searcher.NearbySearch(searchContext, searchReq)
+			if searchErr != nil {
+				result.Error = searchErr.Error()
+			} else {
+				// Redis results are sorted by distance ascending; keep the nearest ones
+				if len(places) > limit {
+					places = places[:limit]
+				}
+				result.Places = places
+			}
+			results[idx] = result
+		}(i, brand)
+	}
+	wg.Wait()
+
+	ctx.JSON(http.StatusOK, gin.H{"results": results})
+}
+
 func (p *MyPlanner) GetPlaceDetails(ctx *gin.Context) {
 	id := ctx.Param("id")
 	if id == "" {
@@ -1412,6 +1497,7 @@ func (p *MyPlanner) SetupRouter(serverPort string) *http.Server {
 		v1.GET("/about", p.aboutPage)
 		v1.GET("/send-password-reset-email", p.resetPasswordHandler)
 		v1.POST("/nearby-cities", p.getNearbyCities)
+		v1.POST("/nearby-places", p.getNearbyPlaces)
 		v1.POST("/optimal-plan", p.getOptimalPlan)
 		v1.POST("/create-token", p.createNewPAT)
 		v1.DELETE("/revoke-token", p.RevokePAT)

--- a/test/known_closed_on_day_test.go
+++ b/test/known_closed_on_day_test.go
@@ -1,0 +1,53 @@
+package test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/weihesdlegend/Vacation-planner/POI"
+)
+
+func TestWeekdayFromTime(t *testing.T) {
+	tests := []struct {
+		goDay time.Weekday
+		want  POI.Weekday
+	}{
+		{time.Monday, POI.DateMonday},
+		{time.Wednesday, POI.DateWednesday},
+		{time.Saturday, POI.DateSaturday},
+		{time.Sunday, POI.DateSunday},
+	}
+	for _, tt := range tests {
+		if got := POI.WeekdayFromTime(tt.goDay); got != tt.want {
+			t.Errorf("WeekdayFromTime(%v) = %v, want %v", tt.goDay, got, tt.want)
+		}
+	}
+}
+
+func TestKnownClosedOnDay(t *testing.T) {
+	place := POI.Place{Hours: [7]string{
+		"Monday: 9:00 AM – 5:00 PM",
+		"Tuesday: 9:00 AM – 5:00 PM",
+		"Wednesday: 9:00 AM – 5:00 PM",
+		"Thursday: 9:00 AM – 5:00 PM",
+		"Friday: 9:00 AM – 5:00 PM",
+		"Saturday: Closed",
+		"Sunday: Closed",
+	}}
+
+	if place.KnownClosedOnDay(POI.DateFriday) {
+		t.Error("expect place to be open on Friday")
+	}
+	if !place.KnownClosedOnDay(POI.DateSaturday) {
+		t.Error("expect place to be closed on Saturday")
+	}
+	if !place.KnownClosedOnDay(POI.DateSunday) {
+		t.Error("expect place to be closed on Sunday")
+	}
+
+	// unknown hours must not be treated as closed
+	unknown := POI.Place{}
+	if unknown.KnownClosedOnDay(POI.DateSunday) {
+		t.Error("expect place with unknown hours to not be reported as closed")
+	}
+}

--- a/test/redis_client_mocks/brand_nearby_search_test.go
+++ b/test/redis_client_mocks/brand_nearby_search_test.go
@@ -1,0 +1,115 @@
+package redis_client_mocks
+
+import (
+	"testing"
+	"time"
+
+	"github.com/weihesdlegend/Vacation-planner/POI"
+	"github.com/weihesdlegend/Vacation-planner/iowrappers"
+)
+
+var brandPlaces = []POI.Place{
+	{
+		ID:               "5005",
+		Name:             "Dunkin'",
+		LocationType:     POI.LocationTypeCafe,
+		Address:          POI.Address{},
+		FormattedAddress: "1 Herald Sq, New York, NY 10001",
+		Location:         POI.Location{Longitude: -73.9876, Latitude: 40.7496},
+		PriceLevel:       POI.PriceLevelOne,
+		Rating:           4.1,
+		Hours:            [7]string{},
+		Status:           POI.Operational,
+	},
+	{
+		ID:               "6006",
+		Name:             "Dunkin' Donuts",
+		LocationType:     POI.LocationTypeCafe,
+		Address:          POI.Address{},
+		FormattedAddress: "255 Northern Blvd, Great Neck, NY 11021",
+		Location:         POI.Location{Longitude: -73.7271, Latitude: 40.7773},
+		PriceLevel:       POI.PriceLevelOne,
+		Rating:           4.0,
+		Hours:            [7]string{},
+		Status:           POI.Operational,
+	},
+}
+
+func TestBrandNearbySearch_shouldOnlyReturnPlacesFromBrandBucket(t *testing.T) {
+	RedisClient.SetPlacesAddGeoLocationsForBrand(RedisContext, "Dunkin'", brandPlaces)
+
+	req := &iowrappers.PlaceSearchRequest{
+		Keyword:  "Dunkin'",
+		Location: POI.Location{Longitude: -74.0060, Latitude: 40.7128},
+		Radius:   uint(8000),
+	}
+
+	cachedBrandPlaces, err := RedisClient.NearbySearch(RedisContext, req)
+	if err != nil {
+		t.Fatalf("RedisClient.NearbySearch error %v", err)
+	}
+
+	// only the Herald Square Dunkin' is within the search radius; the category-bucket
+	// places seeded by other tests (e.g. Keens Steakhouse nearby) must not appear
+	if len(cachedBrandPlaces) != 1 {
+		t.Fatalf("expect to have 1 place, but got %d instead", len(cachedBrandPlaces))
+	}
+	if cachedBrandPlaces[0].ID != brandPlaces[0].ID {
+		t.Errorf("expect to get %s, but got %s instead", brandPlaces[0].Name, cachedBrandPlaces[0].Name)
+	}
+}
+
+func TestBrandMapsLastSearchTime_roundTrip(t *testing.T) {
+	location := POI.Location{City: "New York", AdminAreaLevelOne: "NY", Country: "USA"}
+	currentTime := time.Now()
+
+	if err := RedisClient.SetBrandMapsLastSearchTime(RedisContext, location, "Dunkin'", currentTime.Format(time.RFC3339)); err != nil {
+		t.Fatal(err)
+	}
+
+	gotLastSearchTime, err := RedisClient.GetBrandMapsLastSearchTime(RedisContext, location, "Dunkin'")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotLastSearchTime.Format(time.RFC3339) != currentTime.Format(time.RFC3339) {
+		t.Errorf("expect last search time %v, got %v", currentTime, gotLastSearchTime)
+	}
+}
+
+func TestMatchesBrandName(t *testing.T) {
+	tests := []struct {
+		placeName string
+		keyword   string
+		want      bool
+	}{
+		{"Dunkin' Donuts #1234", "Dunkin'", true},
+		{"Dunkin'", "Dunkin'", true},
+		{"Saks Fifth Avenue", "Saks Fifth Avenue", true},
+		{"Saks OFF 5TH", "Saks Fifth Avenue", false},
+		{"Dunham's Sports", "Dunkin'", false},
+		{"Starbucks", "", false},
+	}
+	for _, tt := range tests {
+		if got := iowrappers.MatchesBrandName(tt.placeName, tt.keyword); got != tt.want {
+			t.Errorf("MatchesBrandName(%q, %q) = %v, want %v", tt.placeName, tt.keyword, got, tt.want)
+		}
+	}
+}
+
+func TestNormalizeBrandKey(t *testing.T) {
+	tests := []struct {
+		keyword string
+		want    string
+	}{
+		{"Dunkin'", "dunkin"},
+		{"Dunkin' Donuts", "dunkin-donuts"},
+		{"Saks Fifth Avenue", "saks-fifth-avenue"},
+		{"  The Home Depot  ", "the-home-depot"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		if got := POI.NormalizeBrandKey(tt.keyword); got != tt.want {
+			t.Errorf("NormalizeBrandKey(%q) = %q, want %q", tt.keyword, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
Nearby search was category-only (Visit/Eatery over 6 Google place types),
so brand-level queries like "Dunkin' near a coordinate" were not expressible.
This adds:

- Keyword (brand) support in PlaceSearchRequest: passes Keyword to Google
  Maps NearbySearch with the place type unset, and caches results under
  brand-scoped Redis geo keys (placeIDs:brand:{brandKey}) so cached brand
  searches stay separate from category buckets
- StrictNameMatch filtering: drops keyword results whose names don't match
  the brand (Google matches keywords against reviews and other content),
  applied before results reach the brand cache
- Brand-aware last-search-time freshness tracking per city
- POST /v1/nearby-places: accepts {brands[], location, radius, limit},
  reverse-geocodes once, fans out per-brand searches concurrently, and
  returns operational places per brand sorted by distance
- processLocation short-circuit when a location already has precise
  coordinates and city-level info, so fan-out callers geocode once

## Description
Clearly describe changes in your PR, new feature or bug fixes.

## Solution
* Describe your code changes in detail for reviewers as well as documentation purposes. 
* For bug fixes, explain the solutions and how they fix the issues.
* For new features, describe the high-level ideas.

## Testing
- [x] Integration testing on Heroku staging
- [x] Added new unit tests

## Checks
- [x] Have you removed commented code?
- [x] Have you used gofmt to format your code?
