### PR TITLE
Require authentication on POST /v1/nearby-places

### DIFF
--- a/planner/nearby_places_auth_test.go
+++ b/planner/nearby_places_auth_test.go
@@ -1,0 +1,71 @@
+package planner
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/weihesdlegend/Vacation-planner/test/redis_client_mocks"
+	"github.com/weihesdlegend/Vacation-planner/user"
+)
+
+// The /v1/nearby-places handler must reject unauthenticated requests before
+// doing any work: each request can fan out a reverse geocode plus up to 25
+// Google Maps searches, so the endpoint cannot be open.
+func TestGetNearbyPlacesRequiresAuth(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	p := &MyPlanner{RedisClient: redis_client_mocks.RedisClient}
+	router := gin.New()
+	router.POST("/v1/nearby-places", p.getNearbyPlaces)
+
+	// zero location: with valid auth this fails request validation (400),
+	// proving the request got past the auth check without needing geocoding
+	body := `{"brands": ["Dunkin'"], "location": {"latitude": 0, "longitude": 0}}`
+
+	post := func(authorization string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPost, "/v1/nearby-places", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		if authorization != "" {
+			req.Header.Set("Authorization", authorization)
+		}
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		return w
+	}
+
+	t.Run("no credentials", func(t *testing.T) {
+		if w := post(""); w.Code != http.StatusUnauthorized {
+			t.Errorf("expected %d without credentials, got %d (%s)", http.StatusUnauthorized, w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("invalid token", func(t *testing.T) {
+		if w := post("Bearer not-a-real-token"); w.Code != http.StatusUnauthorized {
+			t.Errorf("expected %d with an invalid token, got %d (%s)", http.StatusUnauthorized, w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("valid PAT reaches request validation", func(t *testing.T) {
+		userView, err := redis_client_mocks.RedisClient.CreateUser(
+			redis_client_mocks.RedisContext,
+			user.View{Username: "nearby_places_svc", Email: "nearby_places_svc@example.com", Password: "pwd", UserLevel: user.LevelStringRegular},
+			false,
+		)
+		if err != nil {
+			t.Fatalf("failed to create test user: %v", err)
+		}
+		pat, err := redis_client_mocks.RedisClient.NewPAT(
+			redis_client_mocks.RedisContext, "nearby-places-test", userView.ID, "nearby-places-test-token", time.Hour,
+		)
+		if err != nil {
+			t.Fatalf("failed to create test PAT: %v", err)
+		}
+
+		if w := post("Bearer " + pat.TokenHash); w.Code != http.StatusBadRequest {
+			t.Errorf("expected %d (past auth, zero location rejected), got %d (%s)", http.StatusBadRequest, w.Code, w.Body.String())
+		}
+	})
+}

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -1187,7 +1187,14 @@ type nearbyPlacesBrandResult struct {
 
 // getNearbyPlaces returns operational places for each requested brand keyword around a coordinate.
 // Results are served from the brand-scoped Redis geo index when fresh, falling back to Google Maps.
+// Requires authentication (PAT Bearer header or JWT cookie): each request can fan out up to 25
+// Google Maps searches on a cold cache, so the endpoint must not be open.
 func (p *MyPlanner) getNearbyPlaces(ctx *gin.Context) {
+	if _, authErr := p.UserAuthentication(ctx, user.LevelRegular); authErr != nil {
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": authErr.GetErrorMessage()})
+		return
+	}
+
 	req := &nearbyPlacesRequest{}
 	if err := ctx.ShouldBindJSON(req); err != nil {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})


### PR DESCRIPTION
## Why

`POST /v1/nearby-places` (#437) shipped unauthenticated — the `v1` group has no auth middleware and the handler did no check. Each request triggers a reverse geocode plus up to 25 concurrent Google Maps searches on a cold cache, so an open endpoint is a cost/abuse hole for a machine-facing API.

## What

- `getNearbyPlaces` now calls `UserAuthentication(ctx, user.LevelRegular)` before doing any work, following the repo's per-handler auth convention. PAT `Authorization: Bearer` header is checked first, JWT cookie as fallback — so browser sessions keep working.
- Auth failure returns **401** with the standard `{"error": ...}` object shape (consistent with the endpoint's other error responses, so API clients can always read the `error` field).
- New `planner/nearby_places_auth_test.go`: no credentials → 401; invalid token → 401; valid PAT (user + token minted against miniredis) → passes auth and reaches request validation (400 on zero location), with no Google Maps dependency.

## Client provisioning note

Callers now need a PAT: `POST /v1/create-token` with e.g. `{"name": "offerbee-backend", "expiration_duration": "8760h"}`. Note `time.ParseDuration` does not accept a `d` (days) unit despite the field comment's examples, and the default when omitted is only 5 minutes — use hours for long-lived service tokens, and calendar the expiry (PATs always expire).

🤖 Generated with [Claude Code](https://claude.com/claude-code)