### PR TITLE
Add category-based nearby places endpoint

### DIFF
--- a/POI/categories.go
+++ b/POI/categories.go
@@ -10,14 +10,22 @@ type PlaceCategory string
 const (
 	PlaceCategoryVisit  = PlaceCategory("Visit")
 	PlaceCategoryEatery = PlaceCategory("Eatery")
+	// Categories below back the merchant/best-card nearby endpoint. They are not used by
+	// trip planning, which only slots Visit/Eatery places.
+	PlaceCategoryShopping = PlaceCategory("Shopping")
+	PlaceCategoryLodging  = PlaceCategory("Lodging")
+	PlaceCategoryWellness = PlaceCategory("Wellness")
 )
 
 type PlaceIcon string
 
 const (
-	PlaceIconVisit  = PlaceIcon("attractions")
-	PlaceIconEatery = PlaceIcon("restaurant")
-	PlaceIconEmpty  = PlaceIcon("")
+	PlaceIconVisit    = PlaceIcon("attractions")
+	PlaceIconEatery   = PlaceIcon("restaurant")
+	PlaceIconShopping = PlaceIcon("shopping_bag")
+	PlaceIconLodging  = PlaceIcon("hotel")
+	PlaceIconWellness = PlaceIcon("spa")
+	PlaceIconEmpty    = PlaceIcon("")
 )
 
 type LocationType string
@@ -31,14 +39,36 @@ const (
 	LocationTypeGallery       = LocationType("art_gallery")
 	LocationTypeAmusementPark = LocationType("amusement_park")
 	LocationTypePark          = LocationType("park")
+	// Shopping place types
+	LocationTypeShoppingMall    = LocationType("shopping_mall")
+	LocationTypeDepartmentStore = LocationType("department_store")
+	LocationTypeSupermarket     = LocationType("supermarket")
+	LocationTypeClothingStore   = LocationType("clothing_store")
+	LocationTypeStore           = LocationType("store")
+	// Lodging place types
+	LocationTypeLodging = LocationType("lodging")
+	// Wellness place types
+	LocationTypeGym      = LocationType("gym")
+	LocationTypeSpa      = LocationType("spa")
+	LocationTypePharmacy = LocationType("pharmacy")
 )
 
+// GetPlaceCategory maps a Google Maps place type back to its category. It is the inverse of
+// GetPlaceTypes and MUST stay consistent with it: the nearby-search cache writes each place
+// under EncodeNearbySearchRedisKey(GetPlaceCategory(place.LocationType), ...), so a type that
+// resolves to a different category than the one it was searched under would never cache-hit.
 func GetPlaceCategory(placeType LocationType) (placeCategory PlaceCategory) {
 	switch placeType {
 	case LocationTypePark, LocationTypeAmusementPark, LocationTypeGallery, LocationTypeMuseum:
 		placeCategory = PlaceCategoryVisit
 	case LocationTypeCafe, LocationTypeRestaurant:
 		placeCategory = PlaceCategoryEatery
+	case LocationTypeShoppingMall, LocationTypeDepartmentStore, LocationTypeSupermarket, LocationTypeClothingStore, LocationTypeStore:
+		placeCategory = PlaceCategoryShopping
+	case LocationTypeLodging:
+		placeCategory = PlaceCategoryLodging
+	case LocationTypeGym, LocationTypeSpa, LocationTypePharmacy:
+		placeCategory = PlaceCategoryWellness
 	default:
 		placeCategory = PlaceCategoryEatery
 	}
@@ -54,8 +84,29 @@ func GetPlaceTypes(placeCat PlaceCategory) (placeTypes []LocationType) {
 	case PlaceCategoryEatery:
 		placeTypes = append(placeTypes,
 			[]LocationType{LocationTypeCafe, LocationTypeRestaurant}...)
+	case PlaceCategoryShopping:
+		placeTypes = append(placeTypes,
+			[]LocationType{LocationTypeShoppingMall, LocationTypeDepartmentStore, LocationTypeSupermarket, LocationTypeClothingStore, LocationTypeStore}...)
+	case PlaceCategoryLodging:
+		placeTypes = append(placeTypes,
+			[]LocationType{LocationTypeLodging}...)
+	case PlaceCategoryWellness:
+		placeTypes = append(placeTypes,
+			[]LocationType{LocationTypeGym, LocationTypeSpa, LocationTypePharmacy}...)
 	}
 	return
+}
+
+// ParsePlaceCategory converts a category string (e.g. from an API request) into a known
+// PlaceCategory, reporting whether it matched. Matching is exact against the canonical
+// category names ("Eatery", "Shopping", "Lodging", "Wellness", "Visit").
+func ParsePlaceCategory(s string) (PlaceCategory, bool) {
+	switch PlaceCategory(s) {
+	case PlaceCategoryVisit, PlaceCategoryEatery, PlaceCategoryShopping, PlaceCategoryLodging, PlaceCategoryWellness:
+		return PlaceCategory(s), true
+	default:
+		return PlaceCategory(""), false
+	}
 }
 
 // PriceyEatery returns whether a eatery place is expensive based on its price level

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -1273,6 +1273,127 @@ func (p *MyPlanner) getNearbyPlaces(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, gin.H{"results": results})
 }
 
+type nearbyPlacesByCategoryRequest struct {
+	// place categories to search for, e.g. ["Eatery", "Shopping", "Lodging", "Wellness"].
+	// Each must be a known POI.PlaceCategory; unknown categories are rejected.
+	Categories []string     `json:"categories" binding:"required,min=1,max=10"`
+	Location   POI.Location `json:"location"`
+	// search radius in meters; defaults to the maximum search radius when zero
+	Radius uint `json:"radius"`
+	// maximum number of places returned per category
+	Limit int `json:"limit"`
+	// optional RFC3339 timestamp representing local time at the searched location
+	// (e.g. "2026-07-21T13:00:00-07:00"); places whose hours mark them closed on that
+	// weekday are excluded. Defaults to server time when empty.
+	LocalTime string `json:"localTime"`
+}
+
+type nearbyPlacesByCategoryResult struct {
+	Category string      `json:"category"`
+	Places   []POI.Place `json:"places"`
+	Error    string      `json:"error,omitempty"`
+}
+
+// getNearbyPlacesByCategory returns operational places for each requested place category
+// (Eatery, Shopping, Lodging, Wellness, ...) around a coordinate, using place-type search.
+// Results are served from the category-scoped Redis geo index when fresh, falling back to
+// Google Maps. Requires authentication (PAT Bearer header or JWT cookie): each request can
+// fan out several Google Maps searches on a cold cache, so the endpoint must not be open.
+func (p *MyPlanner) getNearbyPlacesByCategory(ctx *gin.Context) {
+	if _, authErr := p.UserAuthentication(ctx, user.LevelRegular); authErr != nil {
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": authErr.GetErrorMessage()})
+		return
+	}
+
+	req := &nearbyPlacesByCategoryRequest{}
+	if err := ctx.ShouldBindJSON(req); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if req.Location.Latitude == 0 && req.Location.Longitude == 0 {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "location with latitude and longitude is required"})
+		return
+	}
+
+	// validate categories up front so a single bad value fails the whole request loudly
+	// rather than silently returning empty results for it
+	categories := make([]POI.PlaceCategory, len(req.Categories))
+	for i, c := range req.Categories {
+		parsed, ok := POI.ParsePlaceCategory(c)
+		if !ok {
+			ctx.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("unknown place category %q", c)})
+			return
+		}
+		categories[i] = parsed
+	}
+
+	radius := req.Radius
+	if radius == 0 || radius > iowrappers.MaxSearchRadius {
+		radius = iowrappers.MaxSearchRadius
+	}
+	limit := req.Limit
+	if limit <= 0 || limit > 20 {
+		limit = 5
+	}
+	day := POI.WeekdayFromTime(time.Now().Weekday())
+	if req.LocalTime != "" {
+		localTime, parseErr := time.Parse(time.RFC3339, req.LocalTime)
+		if parseErr != nil {
+			ctx.JSON(http.StatusBadRequest, gin.H{"error": "localTime must be an RFC3339 timestamp"})
+			return
+		}
+		day = POI.WeekdayFromTime(localTime.Weekday())
+	}
+
+	requestId := requestid.Get(ctx)
+	searchContext := context.WithValue(ctx.Request.Context(), iowrappers.ContextRequestIdKey, requestId)
+
+	// resolve city-level info once so the per-category searches skip geocoding
+	geoQuery, err := p.Solver.Searcher.ReverseGeocode(searchContext, req.Location.Latitude, req.Location.Longitude)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	location := req.Location
+	location.City = geoQuery.City
+	location.AdminAreaLevelOne = geoQuery.AdminAreaLevelOne
+	location.Country = geoQuery.Country
+
+	results := make([]nearbyPlacesByCategoryResult, len(categories))
+	wg := &sync.WaitGroup{}
+	wg.Add(len(categories))
+	for i, category := range categories {
+		go func(idx int, placeCat POI.PlaceCategory) {
+			defer wg.Done()
+			searchReq := &iowrappers.PlaceSearchRequest{
+				PlaceCat:       placeCat,
+				Location:       location,
+				Radius:         radius,
+				MinNumResults:  uint(limit),
+				DetailsLimit:   limit,
+				BusinessStatus: POI.Operational,
+			}
+			result := nearbyPlacesByCategoryResult{Category: string(placeCat), Places: []POI.Place{}}
+			places, searchErr := p.Solver.Searcher.NearbySearch(searchContext, searchReq)
+			if searchErr != nil {
+				result.Error = searchErr.Error()
+			} else if len(places) > 0 {
+				// drop places explicitly marked closed on the requested day
+				places = iowrappers.Filter(places, func(place POI.Place) bool { return !place.KnownClosedOnDay(day) })
+				// Redis results are sorted by distance ascending; keep the nearest ones
+				if len(places) > limit {
+					places = places[:limit]
+				}
+				result.Places = places
+			}
+			results[idx] = result
+		}(i, category)
+	}
+	wg.Wait()
+
+	ctx.JSON(http.StatusOK, gin.H{"results": results})
+}
+
 func (p *MyPlanner) GetPlaceDetails(ctx *gin.Context) {
 	id := ctx.Param("id")
 	if id == "" {
@@ -1521,6 +1642,7 @@ func (p *MyPlanner) SetupRouter(serverPort string) *http.Server {
 		v1.GET("/send-password-reset-email", p.resetPasswordHandler)
 		v1.POST("/nearby-cities", p.getNearbyCities)
 		v1.POST("/nearby-places", p.getNearbyPlaces)
+		v1.POST("/nearby-places-by-category", p.getNearbyPlacesByCategory)
 		v1.POST("/optimal-plan", p.getOptimalPlan)
 		v1.POST("/create-token", p.createNewPAT)
 		v1.DELETE("/revoke-token", p.RevokePAT)

--- a/test/place_category_test.go
+++ b/test/place_category_test.go
@@ -1,0 +1,80 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/weihesdlegend/Vacation-planner/POI"
+)
+
+// TestGetPlaceTypesByCategory pins the Google Maps place types each category expands to.
+func TestGetPlaceTypesByCategory(t *testing.T) {
+	cases := map[POI.PlaceCategory][]POI.LocationType{
+		POI.PlaceCategoryEatery: {POI.LocationTypeCafe, POI.LocationTypeRestaurant},
+		POI.PlaceCategoryShopping: {
+			POI.LocationTypeShoppingMall, POI.LocationTypeDepartmentStore,
+			POI.LocationTypeSupermarket, POI.LocationTypeClothingStore, POI.LocationTypeStore,
+		},
+		POI.PlaceCategoryLodging:  {POI.LocationTypeLodging},
+		POI.PlaceCategoryWellness: {POI.LocationTypeGym, POI.LocationTypeSpa, POI.LocationTypePharmacy},
+	}
+	for category, want := range cases {
+		got := POI.GetPlaceTypes(category)
+		if len(got) != len(want) {
+			t.Fatalf("category %s: got %d place types %v, want %d %v", category, len(got), got, len(want), want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("category %s: place type[%d] = %s, want %s", category, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+// TestPlaceCategoryRoundTrip is the cache-correctness invariant: every place type a category
+// searches for must map back to that same category via GetPlaceCategory. If it does not, the
+// nearby-search cache writes places under one Redis key and reads them under another, so the
+// category can never cache-hit. Covers all searchable categories, new and existing.
+func TestPlaceCategoryRoundTrip(t *testing.T) {
+	categories := []POI.PlaceCategory{
+		POI.PlaceCategoryVisit, POI.PlaceCategoryEatery,
+		POI.PlaceCategoryShopping, POI.PlaceCategoryLodging, POI.PlaceCategoryWellness,
+	}
+	for _, category := range categories {
+		for _, placeType := range POI.GetPlaceTypes(category) {
+			if got := POI.GetPlaceCategory(placeType); got != category {
+				t.Errorf("round-trip broken: GetPlaceCategory(%q) = %q, want %q", placeType, got, category)
+			}
+		}
+	}
+}
+
+func TestParsePlaceCategory(t *testing.T) {
+	valid := []string{"Visit", "Eatery", "Shopping", "Lodging", "Wellness"}
+	for _, s := range valid {
+		if parsed, ok := POI.ParsePlaceCategory(s); !ok || string(parsed) != s {
+			t.Errorf("ParsePlaceCategory(%q) = (%q, %v), want (%q, true)", s, parsed, ok, s)
+		}
+	}
+	for _, s := range []string{"", "shopping", "Restaurant", "food"} {
+		if _, ok := POI.ParsePlaceCategory(s); ok {
+			t.Errorf("ParsePlaceCategory(%q) accepted an unknown category", s)
+		}
+	}
+}
+
+// TestEncodeNearbySearchRedisKeyDistinct guards against two categories sharing a Redis geo
+// bucket, which would cross-contaminate their cached results.
+func TestEncodeNearbySearchRedisKeyDistinct(t *testing.T) {
+	categories := []POI.PlaceCategory{
+		POI.PlaceCategoryVisit, POI.PlaceCategoryEatery,
+		POI.PlaceCategoryShopping, POI.PlaceCategoryLodging, POI.PlaceCategoryWellness,
+	}
+	seen := make(map[string]POI.PlaceCategory)
+	for _, category := range categories {
+		key := POI.EncodeNearbySearchRedisKey(category, POI.PriceLevelDefault)
+		if other, dup := seen[key]; dup {
+			t.Errorf("categories %s and %s share Redis key %q", other, category, key)
+		}
+		seen[key] = category
+	}
+}


### PR DESCRIPTION
## What

New PAT-authed endpoint `POST /v1/nearby-places-by-category` that returns operational places for each requested **place category** (Eatery, Shopping, Lodging, Wellness, Visit) around a coordinate, using Google Maps place-type search.

This complements the existing brand endpoint (`/v1/nearby-places`, #437), which is keyword/brand-based. OfferBee's "best card by location" feature needs merchants grouped by category (what's a *shopping / food / lodging / wellness* place nearby), not by a known brand name.

## Changes

- **`POI/categories.go`**
  - New `PlaceCategory` values `Shopping`, `Lodging`, `Wellness` and their Google Maps place types (`shopping_mall`, `department_store`, `supermarket`, `clothing_store`, `store`; `lodging`; `gym`, `spa`, `pharmacy`).
  - `GetPlaceCategory` (type→category) extended in lockstep with `GetPlaceTypes` (category→types). This round-trip **must** stay consistent: the nearby-search cache buckets each place under `EncodeNearbySearchRedisKey(GetPlaceCategory(place.LocationType), …)`, so a type resolving to a different category than the one it was searched under would never cache-hit.
  - New `ParsePlaceCategory` for request validation.
  - The existing `Eatery` category (cafe, restaurant) is **reused unchanged** for the food bucket, so trip-planner meal slotting is unaffected.
- **`planner/planner.go`**
  - `nearbyPlacesByCategoryRequest` + `getNearbyPlacesByCategory` handler, mirroring the brand `getNearbyPlaces` handler: per-category fan-out via `Searcher.NearbySearch`, day-closed filtering via `localTime`, nearest-N cap per category. Unknown categories are rejected with 400.
  - Route registered **inside the PAT-authed `v1` group** — a cold-cache request fans out several Google Maps searches, so it must not be open.
- **`test/place_category_test.go`** — place-type expansion, the round-trip invariant (all searchable categories), category parsing, Redis-key distinctness.

## Request / response

```
POST /v1/nearby-places-by-category
Authorization: Bearer <PAT>
{
  "categories": ["Eatery", "Shopping", "Lodging", "Wellness"],
  "location": { "latitude": 37.5485, "longitude": -121.9886 },
  "radius": 8000,
  "limit": 5,
  "localTime": "2026-07-27T13:00:00-07:00"
}
```
Response: `{ "results": [ { "category": "Eatery", "places": [ … ] }, … ] }` where each place carries `LocationType`, `PriceLevel`, `Rating`, `Hours`, etc.

## Testing

`go build ./...`, `go vet ./POI/... ./planner/...`, and `go test ./POI/... ./test/... ./planner/...` all pass.