### PR TITLE
Union all price buckets for category eatery search

### DIFF
--- a/POI/places.go
+++ b/POI/places.go
@@ -137,6 +137,15 @@ const (
 	PriceLevelDefault = 2
 )
 
+// AllPriceLevels enumerates the distinct price buckets an eatery can be filed
+// under. Eateries are partitioned by price on write (EncodeNearbySearchRedisKey
+// appends the level only for the Eatery category), so a merchant/category eatery
+// search — which has no price preference — must union across all of these or it
+// only sees one price tier. Other categories are single-bucket.
+var AllPriceLevels = []PriceLevel{
+	PriceLevelZero, PriceLevelOne, PriceLevelTwo, PriceLevelThree, PriceLevelFour,
+}
+
 func (place *Place) GetName() string {
 	return place.Name
 }

--- a/iowrappers/nearby_search.go
+++ b/iowrappers/nearby_search.go
@@ -53,6 +53,13 @@ type PlaceSearchRequest struct {
 	// DetailsLimit caps how many places get the expensive Place Details API call, chosen
 	// by proximity to the request location. Zero means no cap (previous behavior).
 	DetailsLimit int
+
+	// AllPriceLevels, for an Eatery search with no price preference (merchant /
+	// category endpoint), unions every price bucket on read. Eateries are
+	// partitioned by price in the geo index, so without this a category read only
+	// returns the single PriceLevel bucket named by the request. No effect on
+	// non-Eatery categories (they are not price-partitioned) or keyword searches.
+	AllPriceLevels bool
 }
 
 // MatchesBrandName reports whether a place name matches a brand keyword after normalization,

--- a/iowrappers/nearby_search_keys_test.go
+++ b/iowrappers/nearby_search_keys_test.go
@@ -1,0 +1,65 @@
+package iowrappers
+
+import (
+	"testing"
+
+	"github.com/weihesdlegend/Vacation-planner/POI"
+)
+
+func TestNearbySearchRedisKeys(t *testing.T) {
+	t.Run("eatery with AllPriceLevels unions every price bucket", func(t *testing.T) {
+		got := nearbySearchRedisKeys(&PlaceSearchRequest{
+			PlaceCat:       POI.PlaceCategoryEatery,
+			AllPriceLevels: true,
+		})
+		want := []string{
+			"placeIDs:eatery:level0",
+			"placeIDs:eatery:level1",
+			"placeIDs:eatery:level2",
+			"placeIDs:eatery:level3",
+			"placeIDs:eatery:level4",
+		}
+		if len(got) != len(want) {
+			t.Fatalf("got %d keys %v, want %d %v", len(got), got, len(want), want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("key[%d] = %q, want %q", i, got[i], want[i])
+			}
+		}
+	})
+
+	t.Run("eatery without AllPriceLevels reads a single bucket", func(t *testing.T) {
+		got := nearbySearchRedisKeys(&PlaceSearchRequest{
+			PlaceCat:   POI.PlaceCategoryEatery,
+			PriceLevel: POI.PriceLevelTwo,
+		})
+		if len(got) != 1 || got[0] != "placeIDs:eatery:level2" {
+			t.Errorf("got %v, want [placeIDs:eatery:level2]", got)
+		}
+	})
+
+	t.Run("non-eatery categories are single-bucket even with AllPriceLevels", func(t *testing.T) {
+		for _, cat := range []POI.PlaceCategory{
+			POI.PlaceCategoryShopping, POI.PlaceCategoryLodging, POI.PlaceCategoryWellness,
+		} {
+			got := nearbySearchRedisKeys(&PlaceSearchRequest{PlaceCat: cat, AllPriceLevels: true})
+			want := POI.EncodeNearbySearchRedisKey(cat, POI.PriceLevelZero)
+			if len(got) != 1 || got[0] != want {
+				t.Errorf("category %s: got %v, want [%s]", cat, got, want)
+			}
+		}
+	})
+
+	t.Run("keyword search uses the brand bucket, ignoring AllPriceLevels", func(t *testing.T) {
+		got := nearbySearchRedisKeys(&PlaceSearchRequest{
+			Keyword:        "Dunkin'",
+			PlaceCat:       POI.PlaceCategoryEatery,
+			AllPriceLevels: true,
+		})
+		want := POI.EncodeBrandNearbySearchRedisKey("Dunkin'")
+		if len(got) != 1 || got[0] != want {
+			t.Errorf("got %v, want [%s]", got, want)
+		}
+	})
+}

--- a/iowrappers/redis_client.go
+++ b/iowrappers/redis_client.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -443,11 +444,27 @@ func (r *RedisClient) getPlace(context context.Context, placeId string) (place P
 	return
 }
 
-func (r *RedisClient) NearbySearch(ctx context.Context, req *PlaceSearchRequest) ([]POI.Place, error) {
-	redisKey := POI.EncodeNearbySearchRedisKey(req.PlaceCat, req.PriceLevel)
+// nearbySearchRedisKeys returns the geo-index keys a nearby search reads. Usually
+// one key, but an Eatery search with AllPriceLevels set unions every price bucket
+// (placeIDs:eatery:level0..4). Eateries are partitioned by price on write, so a
+// category/merchant search that has no price preference must read them all or it
+// only sees the tier named by req.PriceLevel (e.g. only price-unknown eateries).
+func nearbySearchRedisKeys(req *PlaceSearchRequest) []string {
 	if req.Keyword != "" {
-		redisKey = POI.EncodeBrandNearbySearchRedisKey(req.Keyword)
+		return []string{POI.EncodeBrandNearbySearchRedisKey(req.Keyword)}
 	}
+	if req.AllPriceLevels && req.PlaceCat == POI.PlaceCategoryEatery {
+		keys := make([]string, 0, len(POI.AllPriceLevels))
+		for _, lvl := range POI.AllPriceLevels {
+			keys = append(keys, POI.EncodeNearbySearchRedisKey(req.PlaceCat, lvl))
+		}
+		return keys
+	}
+	return []string{POI.EncodeNearbySearchRedisKey(req.PlaceCat, req.PriceLevel)}
+}
+
+func (r *RedisClient) NearbySearch(ctx context.Context, req *PlaceSearchRequest) ([]POI.Place, error) {
+	redisKeys := nearbySearchRedisKeys(req)
 	requestLat, requestLng := req.Location.Latitude, req.Location.Longitude
 	searchRadius := req.Radius
 
@@ -459,15 +476,34 @@ func (r *RedisClient) NearbySearch(ctx context.Context, req *PlaceSearchRequest)
 	for searchRadius <= MaxSearchRadius {
 		Logger.Debugf("[request_id: %s] Redis geo radius is using search radius of %d meters", ctx.Value(ContextRequestIdKey), searchRadius)
 		geoQuery := &redis.GeoRadiusQuery{
-			Radius: float64(searchRadius),
-			Unit:   "m",
-			Sort:   "ASC", // sort ascending
+			Radius:   float64(searchRadius),
+			Unit:     "m",
+			Sort:     "ASC", // sort ascending
+			WithDist: true,   // needed to merge-sort across multiple buckets
 		}
 
-		var err error
-		if cachedQualifiedPlaces, err = r.client.GeoRadius(ctx, redisKey, requestLng, requestLat, geoQuery).Result(); err != nil {
-			return nil, err
+		// Query each key and union by member, keeping the nearest sighting of a
+		// place that appears in more than one bucket. For the common single-key
+		// case this is one GeoRadius call, unchanged in behavior.
+		merged := make(map[string]redis.GeoLocation)
+		for _, key := range redisKeys {
+			locs, err := r.client.GeoRadius(ctx, key, requestLng, requestLat, geoQuery).Result()
+			if err != nil {
+				return nil, err
+			}
+			for _, loc := range locs {
+				if existing, seen := merged[loc.Name]; !seen || loc.Dist < existing.Dist {
+					merged[loc.Name] = loc
+				}
+			}
 		}
+		cachedQualifiedPlaces = make([]redis.GeoLocation, 0, len(merged))
+		for _, loc := range merged {
+			cachedQualifiedPlaces = append(cachedQualifiedPlaces, loc)
+		}
+		sort.Slice(cachedQualifiedPlaces, func(i, j int) bool {
+			return cachedQualifiedPlaces[i].Dist < cachedQualifiedPlaces[j].Dist
+		})
 		if len(cachedQualifiedPlaces) >= int(req.MinNumResults) {
 			break
 		}

--- a/iowrappers/redis_client.go
+++ b/iowrappers/redis_client.go
@@ -472,38 +472,51 @@ func (r *RedisClient) NearbySearch(ctx context.Context, req *PlaceSearchRequest)
 		searchRadius = MaxSearchRadius
 	}
 
+	// The multi-key union path (WithDist merge-sort) is used ONLY when reading more
+	// than one bucket — i.e. an AllPriceLevels eatery category search. The common
+	// single-key path (plan generation, non-eatery categories, brand searches) is
+	// left exactly as it was: one GeoRadius call, its native ASC order, no re-sort.
+	singleKey := len(redisKeys) == 1
+
 	var cachedQualifiedPlaces []redis.GeoLocation
 	for searchRadius <= MaxSearchRadius {
 		Logger.Debugf("[request_id: %s] Redis geo radius is using search radius of %d meters", ctx.Value(ContextRequestIdKey), searchRadius)
 		geoQuery := &redis.GeoRadiusQuery{
 			Radius:   float64(searchRadius),
 			Unit:     "m",
-			Sort:     "ASC", // sort ascending
-			WithDist: true,   // needed to merge-sort across multiple buckets
+			Sort:     "ASC",      // sort ascending
+			WithDist: !singleKey, // only needed to merge-sort across multiple buckets
 		}
 
-		// Query each key and union by member, keeping the nearest sighting of a
-		// place that appears in more than one bucket. For the common single-key
-		// case this is one GeoRadius call, unchanged in behavior.
-		merged := make(map[string]redis.GeoLocation)
-		for _, key := range redisKeys {
-			locs, err := r.client.GeoRadius(ctx, key, requestLng, requestLat, geoQuery).Result()
-			if err != nil {
+		if singleKey {
+			var err error
+			if cachedQualifiedPlaces, err = r.client.GeoRadius(ctx, redisKeys[0], requestLng, requestLat, geoQuery).Result(); err != nil {
 				return nil, err
 			}
-			for _, loc := range locs {
-				if existing, seen := merged[loc.Name]; !seen || loc.Dist < existing.Dist {
-					merged[loc.Name] = loc
+		} else {
+			// Union across buckets by member, keeping the nearest sighting of a place
+			// that appears in more than one, then merge-sort by distance.
+			merged := make(map[string]redis.GeoLocation)
+			for _, key := range redisKeys {
+				locs, err := r.client.GeoRadius(ctx, key, requestLng, requestLat, geoQuery).Result()
+				if err != nil {
+					return nil, err
+				}
+				for _, loc := range locs {
+					if existing, seen := merged[loc.Name]; !seen || loc.Dist < existing.Dist {
+						merged[loc.Name] = loc
+					}
 				}
 			}
+			cachedQualifiedPlaces = make([]redis.GeoLocation, 0, len(merged))
+			for _, loc := range merged {
+				cachedQualifiedPlaces = append(cachedQualifiedPlaces, loc)
+			}
+			sort.SliceStable(cachedQualifiedPlaces, func(i, j int) bool {
+				return cachedQualifiedPlaces[i].Dist < cachedQualifiedPlaces[j].Dist
+			})
 		}
-		cachedQualifiedPlaces = make([]redis.GeoLocation, 0, len(merged))
-		for _, loc := range merged {
-			cachedQualifiedPlaces = append(cachedQualifiedPlaces, loc)
-		}
-		sort.Slice(cachedQualifiedPlaces, func(i, j int) bool {
-			return cachedQualifiedPlaces[i].Dist < cachedQualifiedPlaces[j].Dist
-		})
+
 		if len(cachedQualifiedPlaces) >= int(req.MinNumResults) {
 			break
 		}

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -1372,6 +1372,9 @@ func (p *MyPlanner) getNearbyPlacesByCategory(ctx *gin.Context) {
 				MinNumResults:  uint(limit),
 				DetailsLimit:   limit,
 				BusinessStatus: POI.Operational,
+				// Merchant search has no price preference: union all eatery price
+				// buckets so the food category isn't limited to one price tier.
+				AllPriceLevels: true,
 			}
 			result := nearbyPlacesByCategoryResult{Category: string(placeCat), Places: []POI.Place{}}
 			places, searchErr := p.Solver.Searcher.NearbySearch(searchContext, searchReq)


### PR DESCRIPTION
## Problem

`POST /v1/nearby-places-by-category` with `categories:["Eatery"]` returns almost no nearby restaurants. In testing, `radius:8000, limit:20` returned a handful of places, mostly outside the radius, and obvious chains (Subway, Chipotle, Starbucks, In-N-Out) were absent — even though `/v1/nearby-places` (brand) finds them instantly at the same coordinate. Raising `limit` doesn't help; results are distance-sorted, so it only appends farther places.

## Root cause

Eateries are **partitioned by price** in the geo index: `EncodeNearbySearchRedisKey` appends `:level{N}` **only** for the `Eatery` category. So on write, each eatery is filed under `placeIDs:eatery:level{its price level}`. But the read only queried the **single** bucket named by `req.PriceLevel`, which the category handler leaves at `0`. Any eatery Google reports at price ≥ 1 (i.e. most restaurants) lands in `level1..4` and is never read. The radius-expansion loop then keeps doubling the radius trying to reach `MinNumResults` from the sparse `level0` bucket, pulling in far-away places.

Non-Eatery categories (Shopping/Lodging/Wellness/Visit) aren't price-partitioned, so they were unaffected.

## Fix

- **`PlaceSearchRequest.AllPriceLevels`** — when set for an Eatery search, the read unions every price bucket (`placeIDs:eatery:level0..4`). No effect on non-Eatery categories or keyword searches.
- **`RedisClient.NearbySearch`** — new `nearbySearchRedisKeys()` selects the key set; the geo read queries each key (`WithDist`), unions by member keeping the nearest sighting of any place in more than one bucket, and merge-sorts by distance. The common single-key path is behavior-identical.
- **`getNearbyPlacesByCategory`** sets `AllPriceLevels: true` (a merchant/category search has no price preference). `POI.AllPriceLevels` enumerates the buckets.

## Testing

`go build ./...`, `go test ./POI/... ./iowrappers/... ./planner/... ./test/...` pass, plus a new `TestNearbySearchRedisKeys` covering eatery-all-buckets / eatery-single-bucket / non-eatery-single / keyword key selection.

Note: existing warm caches carry pre-fix `level0` data; a fresh search (or Redis flush) repopulates all buckets. A follow-up could also distance-sort before the `[:limit]` cut so a cold-cache prominence result set doesn't drop a closer place.