### PR TITLE
Classify category-endpoint places by primary Google type

### DIFF
--- a/POI/categories.go
+++ b/POI/categories.go
@@ -109,6 +109,57 @@ func ParsePlaceCategory(s string) (PlaceCategory, bool) {
 	}
 }
 
+// umbrellaLocationTypes are Google's generic feature types that describe almost
+// every place and say nothing about its primary function. They are skipped when
+// picking a place's primary type.
+// Note: "store" is intentionally NOT here — it is a meaningful Shopping type.
+var umbrellaLocationTypes = map[LocationType]bool{
+	LocationType("food"):              true,
+	LocationType("point_of_interest"): true,
+	LocationType("establishment"):     true,
+	LocationType("premise"):           true,
+	LocationType("geocode"):           true,
+	LocationType("political"):         true,
+}
+
+// PrimaryLocationType returns a place's primary Google feature type: the first
+// entry in its Types list that isn't a generic umbrella (food, point_of_interest,
+// …). Google lists the most specific type first, so this is the place's real
+// function (e.g. "supermarket" for a store the restaurant search also matched).
+// Returns "" when there is no meaningful type (empty/unknown Types).
+func PrimaryLocationType(types []string) LocationType {
+	for _, t := range types {
+		lt := LocationType(t)
+		if !umbrellaLocationTypes[lt] {
+			return lt
+		}
+	}
+	return LocationType("")
+}
+
+// ReclassifyForCategory decides whether a place belongs in cat based on its
+// PRIMARY function, and returns the place re-tagged with that primary type.
+//
+//   - primary type is one of cat's search types  → keep, LocationType := primary
+//     (e.g. a "cafe"-searched result that is really a restaurant is re-tagged).
+//   - primary type is known but NOT in cat        → drop (keep=false): its main
+//     function is something else (a supermarket the food search returned).
+//   - no Types on the place (older cached records) → keep unchanged, so coverage
+//     never regresses on data written before Types was captured.
+func ReclassifyForCategory(place Place, cat PlaceCategory) (Place, bool) {
+	primary := PrimaryLocationType(place.Types)
+	if primary == LocationType("") {
+		return place, true
+	}
+	for _, t := range GetPlaceTypes(cat) {
+		if t == primary {
+			place.LocationType = primary
+			return place, true
+		}
+	}
+	return place, false
+}
+
 // PriceyEatery returns whether a eatery place is expensive based on its price level
 func PriceyEatery(placeCategory PlaceCategory, priceLevel PriceLevel) bool {
 	return (placeCategory == PlaceCategoryEatery) && (priceLevel >= PriceLevelThree)

--- a/POI/places.go
+++ b/POI/places.go
@@ -67,21 +67,28 @@ const (
 )
 
 type Place struct {
-	ID               string         `bson:"_id"`
-	Name             string         `bson:"name"`
-	Status           BusinessStatus `bson:"status"`
-	LocationType     LocationType   `bson:"location_type"`
-	Address          Address        `bson:"address"`
-	FormattedAddress string         `bson:"formatted_address"`
-	Location         Location       `bson:"location"`
-	PriceLevel       PriceLevel     `bson:"price_level"`
-	Rating           float32        `bson:"rating"`
-	Hours            [7]string      `bson:"hours"`
-	URL              string         `bson:"url"`
-	Photo            PlacePhoto     `bson:"photo"`
-	UserRatingsTotal int            `bson:"user_ratings_total"`
-	Summary          string         `bson:"summary"`
-	LastUpdatedAt    string         `bson:"last_updated_at"`
+	ID           string         `bson:"_id"`
+	Name         string         `bson:"name"`
+	Status       BusinessStatus `bson:"status"`
+	LocationType LocationType   `bson:"location_type"`
+	// Types is the full Google Maps feature-type list for the place (primary type
+	// first), e.g. ["supermarket","grocery_or_supermarket","food",...]. LocationType
+	// above is the single type a search tagged the place with (often the SEARCHED
+	// type, not the actual one); Types preserves the truth so callers can classify
+	// a place by its primary function. Populated on nearby search; may be empty on
+	// older cached records.
+	Types            []string   `bson:"types"`
+	Address          Address    `bson:"address"`
+	FormattedAddress string     `bson:"formatted_address"`
+	Location         Location   `bson:"location"`
+	PriceLevel       PriceLevel `bson:"price_level"`
+	Rating           float32    `bson:"rating"`
+	Hours            [7]string  `bson:"hours"`
+	URL              string     `bson:"url"`
+	Photo            PlacePhoto `bson:"photo"`
+	UserRatingsTotal int        `bson:"user_ratings_total"`
+	Summary          string     `bson:"summary"`
+	LastUpdatedAt    string     `bson:"last_updated_at"`
 }
 
 type Location struct {

--- a/iowrappers/nearby_search.go
+++ b/iowrappers/nearby_search.go
@@ -378,7 +378,11 @@ func parsePlacesSearchResponse(resp maps.PlacesSearchResponse, locationType POI.
 			placeSummary = &summary
 		}
 
-		places = append(places, POI.CreatePlace(name, addr, res.FormattedAddress, res.BusinessStatus, locationType, h, id, priceLevel, rating, url, photo, userRatingsTotal, latitude, longitude, placeSummary))
+		place := POI.CreatePlace(name, addr, res.FormattedAddress, res.BusinessStatus, locationType, h, id, priceLevel, rating, url, photo, userRatingsTotal, latitude, longitude, placeSummary)
+		// Preserve Google's actual feature types so callers can classify the place by
+		// its primary function, not the type this search happened to query for.
+		place.Types = res.Types
+		places = append(places, place)
 	}
 	return
 }

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -1381,6 +1381,19 @@ func (p *MyPlanner) getNearbyPlacesByCategory(ctx *gin.Context) {
 			if searchErr != nil {
 				result.Error = searchErr.Error()
 			} else if len(places) > 0 {
+				// Classify each result by its PRIMARY Google type, not the type this
+				// search queried for: a place-type search also matches places with the
+				// type as a secondary attribute (a supermarket with a deli matches a
+				// restaurant search). Drop places whose main function isn't this
+				// category — they surface under their own category's search instead —
+				// and re-tag the rest with their true type so card rewards are correct.
+				reclassified := make([]POI.Place, 0, len(places))
+				for _, place := range places {
+					if rp, keep := POI.ReclassifyForCategory(place, placeCat); keep {
+						reclassified = append(reclassified, rp)
+					}
+				}
+				places = reclassified
 				// drop places explicitly marked closed on the requested day
 				places = iowrappers.Filter(places, func(place POI.Place) bool { return !place.KnownClosedOnDay(day) })
 				// Redis results are sorted by distance ascending; keep the nearest ones

--- a/test/place_category_test.go
+++ b/test/place_category_test.go
@@ -78,3 +78,72 @@ func TestEncodeNearbySearchRedisKeyDistinct(t *testing.T) {
 		seen[key] = category
 	}
 }
+
+func TestPrimaryLocationType(t *testing.T) {
+	cases := []struct {
+		name  string
+		types []string
+		want  POI.LocationType
+	}{
+		{"restaurant first", []string{"restaurant", "food", "point_of_interest", "establishment"}, POI.LocationTypeRestaurant},
+		{"supermarket before secondary restaurant", []string{"supermarket", "grocery_or_supermarket", "food", "store", "point_of_interest"}, POI.LocationTypeSupermarket},
+		{"skips leading umbrella types", []string{"food", "point_of_interest", "cafe", "establishment"}, POI.LocationTypeCafe},
+		{"cinema", []string{"movie_theater", "point_of_interest", "establishment"}, POI.LocationType("movie_theater")},
+		{"empty -> unknown", nil, POI.LocationType("")},
+		{"all umbrella -> unknown", []string{"point_of_interest", "establishment"}, POI.LocationType("")},
+	}
+	for _, tc := range cases {
+		if got := POI.PrimaryLocationType(tc.types); got != tc.want {
+			t.Errorf("%s: PrimaryLocationType(%v) = %q, want %q", tc.name, tc.types, got, tc.want)
+		}
+	}
+}
+
+func TestReclassifyForCategory(t *testing.T) {
+	t.Run("supermarket returned by the food search is dropped from Eatery", func(t *testing.T) {
+		p := POI.Place{LocationType: POI.LocationTypeRestaurant, Types: []string{"supermarket", "grocery_or_supermarket", "food", "store"}}
+		if _, keep := POI.ReclassifyForCategory(p, POI.PlaceCategoryEatery); keep {
+			t.Error("expected a supermarket to be dropped from the Eatery category")
+		}
+	})
+
+	t.Run("same supermarket is kept under Shopping, tagged supermarket", func(t *testing.T) {
+		p := POI.Place{LocationType: POI.LocationTypeSupermarket, Types: []string{"supermarket", "grocery_or_supermarket", "food", "store"}}
+		rp, keep := POI.ReclassifyForCategory(p, POI.PlaceCategoryShopping)
+		if !keep {
+			t.Fatal("expected a supermarket to be kept under Shopping")
+		}
+		if rp.LocationType != POI.LocationTypeSupermarket {
+			t.Errorf("LocationType = %q, want supermarket", rp.LocationType)
+		}
+	})
+
+	t.Run("real restaurant found via cafe search is re-tagged restaurant and kept", func(t *testing.T) {
+		p := POI.Place{LocationType: POI.LocationTypeCafe, Types: []string{"restaurant", "food", "point_of_interest"}}
+		rp, keep := POI.ReclassifyForCategory(p, POI.PlaceCategoryEatery)
+		if !keep {
+			t.Fatal("expected a restaurant to be kept in Eatery")
+		}
+		if rp.LocationType != POI.LocationTypeRestaurant {
+			t.Errorf("LocationType = %q, want restaurant", rp.LocationType)
+		}
+	})
+
+	t.Run("cinema is dropped from Eatery (no matching category type)", func(t *testing.T) {
+		p := POI.Place{LocationType: POI.LocationTypeRestaurant, Types: []string{"movie_theater", "point_of_interest", "establishment"}}
+		if _, keep := POI.ReclassifyForCategory(p, POI.PlaceCategoryEatery); keep {
+			t.Error("expected a cinema to be dropped from the Eatery category")
+		}
+	})
+
+	t.Run("place with no Types is kept unchanged (older cache records)", func(t *testing.T) {
+		p := POI.Place{LocationType: POI.LocationTypeRestaurant}
+		rp, keep := POI.ReclassifyForCategory(p, POI.PlaceCategoryEatery)
+		if !keep {
+			t.Fatal("expected a Types-less place to be kept")
+		}
+		if rp.LocationType != POI.LocationTypeRestaurant {
+			t.Errorf("LocationType = %q, want restaurant (unchanged)", rp.LocationType)
+		}
+	})
+}


### PR DESCRIPTION
## Problem

`POST /v1/nearby-places-by-category` returns businesses tagged with the **searched** place type, not their real one. Google returns a place for a `type=restaurant` search if it merely has `restaurant` as a *secondary* type, so a live audit at Fremont Civic Center surfaced:

| Place | Returned type | Actually is |
|---|---|---|
| Seafood City Supermarket | `restaurant` | grocery |
| Cinemark Century Union Landing | `restaurant` | cinema |
| Bay View Golf Club / Golfland | `restaurant` | recreation |
| Loop Neighborhood Market | `cafe` | convenience/grocery |
| Foodmaxx | `supermarket` | not food |
| Ace Hardware | `store` | not food |

Downstream (OfferBee best-card), a supermarket tagged `restaurant` earns the user's **dining** multiplier — wrong card, wrong rate — and non-food results consume the app's per-category slots. Root cause: `parsePlacesSearchResponse` assigns the searched type, and `POI.Place` discarded Google's real `Types` array.

## Fix

Classify each place by its **primary** function and let it appear only in the category that function belongs to.

- **`POI.Place`** gains `Types []string`; `parsePlacesSearchResponse` populates it from `maps.PlacesSearchResult.Types` (additive; trip planning ignores it).
- **`POI.PrimaryLocationType(types)`** — first non-umbrella type (`food`, `point_of_interest`, `establishment`, …); Google lists the most specific type first.
- **`POI.ReclassifyForCategory(place, cat)`** — keep + re-tag when the primary type is one of the category's search types; drop when the primary function is elsewhere (it surfaces under its own category's search instead); keep unchanged when `Types` is empty (older cached records → no coverage regression).
- **`getNearbyPlacesByCategory`** maps results through `ReclassifyForCategory` before the day-closed filter + nearest-N cap.

Out-of-scope primary types (movie_theater, golf, convenience_store, hardware_store) have no matching category and are omitted for now. No consumer/client change needed — the corrected `LocationType` flows through unchanged.

## Result

- Eatery returns only real cafes/restaurants; a supermarket the food search matched is dropped from Food and appears under Shopping tagged `supermarket` (→ grocery reward).
- Robust to existing cache pollution: reclassification happens at response time from `Types`, so mis-bucketed places are corrected on read.

## Testing

`go build ./...`; `go test ./POI/... ./iowrappers/... ./planner/... ./matching/... ./test/...` pass, incl. new `TestPrimaryLocationType` and `TestReclassifyForCategory` (supermarket-dropped-from-Eatery, kept-under-Shopping, cafe→restaurant re-tag, cinema dropped, empty-Types kept).

Note: existing warm caches carry pre-fix records; the filter corrects responses regardless, and `redis-cli FLUSHDB` fully repopulates with accurate types.