### PR TITLE
Widen category place search cap for brand-dedup headroom

### DIFF
--- a/planner/planner.go
+++ b/planner/planner.go
@@ -1210,8 +1210,14 @@ func (p *MyPlanner) getNearbyPlaces(ctx *gin.Context) {
 		radius = iowrappers.MaxSearchRadius
 	}
 	limit := req.Limit
-	if limit <= 0 || limit > 20 {
+	if limit <= 0 {
 		limit = 5
+	}
+	// Clamp (don't fall back to the tiny default) so a caller can widen the
+	// candidate pool — the merchant endpoint fetches extra so brand-dedup and
+	// distance ranking downstream still yield a full, diverse list.
+	if limit > 40 {
+		limit = 40
 	}
 	day := POI.WeekdayFromTime(time.Now().Weekday())
 	if req.LocalTime != "" {
@@ -1332,8 +1338,14 @@ func (p *MyPlanner) getNearbyPlacesByCategory(ctx *gin.Context) {
 		radius = iowrappers.MaxSearchRadius
 	}
 	limit := req.Limit
-	if limit <= 0 || limit > 20 {
+	if limit <= 0 {
 		limit = 5
+	}
+	// Clamp (don't fall back to the tiny default) so a caller can widen the
+	// candidate pool — the merchant endpoint fetches extra so brand-dedup and
+	// distance ranking downstream still yield a full, diverse list.
+	if limit > 40 {
+		limit = 40
 	}
 	day := POI.WeekdayFromTime(time.Now().Weekday())
 	if req.LocalTime != "" {
@@ -1366,11 +1378,13 @@ func (p *MyPlanner) getNearbyPlacesByCategory(ctx *gin.Context) {
 		go func(idx int, placeCat POI.PlaceCategory) {
 			defer wg.Done()
 			searchReq := &iowrappers.PlaceSearchRequest{
-				PlaceCat:       placeCat,
-				Location:       location,
-				Radius:         radius,
-				MinNumResults:  uint(limit),
-				DetailsLimit:   limit,
+				PlaceCat:      placeCat,
+				Location:      location,
+				Radius:        radius,
+				MinNumResults: uint(limit),
+				// Bound the expensive Place Details calls even when the candidate
+				// pool (limit) is widened for dedup — details cost stays ~today's.
+				DetailsLimit:   min(limit, 20),
 				BusinessStatus: POI.Operational,
 				// Merchant search has no price preference: union all eatery price
 				// buckets so the food category isn't limited to one price tier.


### PR DESCRIPTION
## Why

OfferBee's Best Card → Location "Food & drink" list is chain-dominated — a live audit returned **9 Starbucks in the nearest 20**. The client will dedup by brand (one location per merchant), but with only 20 candidates the deduped list ends up sparse and farther unique local spots never appear. The category endpoint needs a bigger pool.

## Change

`getNearbyPlacesByCategory`:
- Raise the per-category cap **20 → 40**, and **clamp** over-cap values instead of the old `limit > 20 → 5`, which silently gutted any larger request back to the tiny default.
- `DetailsLimit: min(limit, 20)` so widening the pool only adds Nearby-Search pagination (already parallelized across place types), **not** expensive Place Details calls — cost stays ~today's.

`getNearbyPlaces` (brand) shares the identical `limit` block and gets the same clamp; no behavior change in practice since brand callers pass small limits (≤20).

## Testing

`go build ./...`, `go test ./planner/... ./iowrappers/...` pass.

Pairs with an OfferBee-side change that bumps `PLACES_PER_CATEGORY` to 40 and dedups by brand. **Deploy note:** this needs to reach Heroku (`git push heroku master`) before the client requests 40 — otherwise the pre-deploy cap sends >20 back to 5.