### PR TITLE
Broaden Eatery category: bar, bakery, meal_takeaway

### DIFF
--- a/POI/categories.go
+++ b/POI/categories.go
@@ -35,6 +35,9 @@ const (
 	LocationTypeAny           = LocationType("")
 	LocationTypeCafe          = LocationType("cafe")
 	LocationTypeRestaurant    = LocationType("restaurant")
+	LocationTypeBar           = LocationType("bar")
+	LocationTypeBakery        = LocationType("bakery")
+	LocationTypeMealTakeaway  = LocationType("meal_takeaway")
 	LocationTypeMuseum        = LocationType("museum")
 	LocationTypeGallery       = LocationType("art_gallery")
 	LocationTypeAmusementPark = LocationType("amusement_park")
@@ -61,7 +64,7 @@ func GetPlaceCategory(placeType LocationType) (placeCategory PlaceCategory) {
 	switch placeType {
 	case LocationTypePark, LocationTypeAmusementPark, LocationTypeGallery, LocationTypeMuseum:
 		placeCategory = PlaceCategoryVisit
-	case LocationTypeCafe, LocationTypeRestaurant:
+	case LocationTypeCafe, LocationTypeRestaurant, LocationTypeBar, LocationTypeBakery, LocationTypeMealTakeaway:
 		placeCategory = PlaceCategoryEatery
 	case LocationTypeShoppingMall, LocationTypeDepartmentStore, LocationTypeSupermarket, LocationTypeClothingStore, LocationTypeStore:
 		placeCategory = PlaceCategoryShopping
@@ -83,7 +86,7 @@ func GetPlaceTypes(placeCat PlaceCategory) (placeTypes []LocationType) {
 			[]LocationType{LocationTypePark, LocationTypeAmusementPark, LocationTypeGallery, LocationTypeMuseum}...)
 	case PlaceCategoryEatery:
 		placeTypes = append(placeTypes,
-			[]LocationType{LocationTypeCafe, LocationTypeRestaurant}...)
+			[]LocationType{LocationTypeCafe, LocationTypeRestaurant, LocationTypeBar, LocationTypeBakery, LocationTypeMealTakeaway}...)
 	case PlaceCategoryShopping:
 		placeTypes = append(placeTypes,
 			[]LocationType{LocationTypeShoppingMall, LocationTypeDepartmentStore, LocationTypeSupermarket, LocationTypeClothingStore, LocationTypeStore}...)

--- a/test/place_category_test.go
+++ b/test/place_category_test.go
@@ -9,7 +9,10 @@ import (
 // TestGetPlaceTypesByCategory pins the Google Maps place types each category expands to.
 func TestGetPlaceTypesByCategory(t *testing.T) {
 	cases := map[POI.PlaceCategory][]POI.LocationType{
-		POI.PlaceCategoryEatery: {POI.LocationTypeCafe, POI.LocationTypeRestaurant},
+		POI.PlaceCategoryEatery: {
+			POI.LocationTypeCafe, POI.LocationTypeRestaurant,
+			POI.LocationTypeBar, POI.LocationTypeBakery, POI.LocationTypeMealTakeaway,
+		},
 		POI.PlaceCategoryShopping: {
 			POI.LocationTypeShoppingMall, POI.LocationTypeDepartmentStore,
 			POI.LocationTypeSupermarket, POI.LocationTypeClothingStore, POI.LocationTypeStore,


### PR DESCRIPTION
## Why

The "Food & drink" (Eatery) category searched only `cafe` + `restaurant`, so it had **no drink venues** and missed **bakeries** and **fast-casual/takeout** spots (burger joints, taquerias, delis). This broadens coverage of the category.

## Change

`POI/categories.go`: add `bar`, `bakery`, `meal_takeaway` to `GetPlaceTypes(Eatery)` and — in lockstep — to `GetPlaceCategory` (the type→category round-trip must stay consistent, or the nearby-search cache writes/reads under mismatched keys and never hits; guarded by `TestPlaceCategoryRoundTrip`).

Skipped `meal_delivery` — ghost/delivery-only kitchens aren't places you can visit, so they'd be noise in a "near me" list.

No reward-mapping change: OfferBee's `cardRewards.ts` already maps `bar`/`bakery`/`meal_takeaway` → Dining.

## Testing

`go build ./...`, `go test ./POI/... ./iowrappers/... ./planner/... ./test/...` pass (incl. the round-trip and place-type-expansion tests, updated for the new Eatery set).

Note: legacy Google Nearby Search `type` supports these; richer cuisine types (pizza_restaurant, sushi_restaurant, …) would need a Places API (New) migration — separate effort.