### PR TITLE
Expand Visit category search to entertainment venue types

### DIFF
--- a/POI/categories.go
+++ b/POI/categories.go
@@ -205,7 +205,12 @@ func GetPlaceTypes(placeCat PlaceCategory) (placeTypes []LocationType) {
 	switch placeCat {
 	case PlaceCategoryVisit:
 		placeTypes = append(placeTypes,
-			[]LocationType{LocationTypePark, LocationTypeAmusementPark, LocationTypeGallery, LocationTypeMuseum}...)
+			[]LocationType{
+				LocationTypePark, LocationTypeAmusementPark, LocationTypeGallery, LocationTypeMuseum,
+				LocationTypeMovieTheater, LocationTypeBowlingAlley,
+				LocationTypeZoo, LocationTypeAquarium,
+				LocationTypeStadium, LocationTypeTouristAttraction,
+			}...)
 	case PlaceCategoryEatery:
 		placeTypes = append(placeTypes,
 			[]LocationType{LocationTypeCafe, LocationTypeRestaurant, LocationTypeBar, LocationTypeBakery, LocationTypeMealTakeaway}...)

--- a/test/place_category_test.go
+++ b/test/place_category_test.go
@@ -13,6 +13,9 @@ func TestGetPlaceTypesByCategory(t *testing.T) {
 		POI.PlaceCategoryVisit: {
 			POI.LocationTypePark, POI.LocationTypeAmusementPark,
 			POI.LocationTypeGallery, POI.LocationTypeMuseum,
+			POI.LocationTypeMovieTheater, POI.LocationTypeBowlingAlley,
+			POI.LocationTypeZoo, POI.LocationTypeAquarium,
+			POI.LocationTypeStadium, POI.LocationTypeTouristAttraction,
 		},
 		POI.PlaceCategoryEatery: {
 			POI.LocationTypeCafe, POI.LocationTypeRestaurant,


### PR DESCRIPTION
`GetPlaceTypes(Visit)` grows 4 → 10 types: + movie_theater, bowling_alley, zoo, aquarium, stadium, tourist_attraction. All six are valid legacy Nearby Search `type` values and were already classified to Visit in `placeTypeToCategory` (the cache round-trip invariant holds — `TestPlaceCategoryRoundTrip` covers them), but they were never *searched* — so nearby-by-category results never contained these venue types; they could only enter the cache via one-off text-search confirms.

- Cost: a cold Visit search's per-round fan-out rises from 4 to 10 concurrent Nearby calls; warm cells are unaffected.
- Rollout: cells with a fresh Visit marker pick up the new types as their markers age out (14 days). Optional ops accelerant: `HDEL` the `<cell>:visit` fields from `MapsLastSearchTime` for high-traffic cells.

Tests: `TestGetPlaceTypesByCategory` pin updated; round-trip invariant green; `go vet` + full suite green (7 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DjdGnZM6cUBeg6jWwoQfU3