### PR TITLE
Derive LocationType from the primary Google type for keyword searches

### DIFF
--- a/iowrappers/nearby_search.go
+++ b/iowrappers/nearby_search.go
@@ -364,6 +364,9 @@ func restoreCachedDetails(places []POI.Place, cached map[string]POI.Place) {
 		if places[i].Address == (POI.Address{}) {
 			places[i].Address = stored.Address
 		}
+		if places[i].LocationType == POI.LocationTypeAny {
+			places[i].LocationType = stored.LocationType
+		}
 		if !places[i].HasRealOpeningHours() && stored.HasRealOpeningHours() {
 			places[i].Hours = stored.Hours
 		}
@@ -501,6 +504,14 @@ func parsePlacesSearchResponse(resp maps.PlacesSearchResponse, locationType POI.
 		// Preserve Google's actual feature types so callers can classify the place by
 		// its primary function, not the type this search happened to query for.
 		place.Types = res.Types
+		// Keyword (brand) searches query with LocationTypeAny, so the searched-type
+		// stamp above is blank — and the blind-upsert write path would cache (and
+		// overwrite typed records with) LocationType "". Derive the real type from
+		// the place's primary Google feature type instead. Typed searches keep their
+		// stamp: re-tagging those is ReclassifyForCategory's job on the category paths.
+		if locationType == POI.LocationTypeAny {
+			place.LocationType = POI.PrimaryLocationType(place.Types)
+		}
 		places = append(places, place)
 	}
 	return

--- a/iowrappers/nearby_search_test.go
+++ b/iowrappers/nearby_search_test.go
@@ -164,6 +164,78 @@ func TestSelectPlacesForDetailsSkipsCachedPlaces(t *testing.T) {
 	})
 }
 
+// TestParsePlacesSearchResponseKeywordDerivesLocationType covers the keyword (brand) search
+// path: it queries Google with LocationTypeAny, so stamping results with the searched type
+// caches LocationType "" — and the blind-upsert write path then wipes the type off any
+// previously typed record (a McDonald's cached by an Eatery search served with no type).
+// The parser must fall back to the place's primary Google feature type instead.
+func TestParsePlacesSearchResponseKeywordDerivesLocationType(t *testing.T) {
+	resp := maps.PlacesSearchResponse{
+		Results: []maps.PlacesSearchResult{
+			{
+				Name:             "McDonald's",
+				PlaceID:          "mcd",
+				Geometry:         maps.AddressGeometry{Location: maps.LatLng{Lat: 37.32, Lng: -122.03}},
+				Types:            []string{"meal_takeaway", "food", "point_of_interest", "establishment"},
+				UserRatingsTotal: 100,
+			},
+			{ // umbrella types only: no meaningful primary type to derive
+				Name:             "Mystery Venue",
+				PlaceID:          "untyped",
+				Geometry:         maps.AddressGeometry{Location: maps.LatLng{Lat: 37.33, Lng: -122.04}},
+				Types:            []string{"point_of_interest", "establishment"},
+				UserRatingsTotal: 5,
+			},
+		},
+	}
+
+	t.Run("a keyword search derives the type from the place's primary Google type", func(t *testing.T) {
+		places := parsePlacesSearchResponse(resp, POI.LocationTypeAny, nil, map[string]bool{}, nil, nil)
+		if len(places) != 2 {
+			t.Fatalf("expect 2 places parsed, got %d", len(places))
+		}
+		if places[0].LocationType != POI.LocationTypeMealTakeaway {
+			t.Errorf("LocationType = %q, want %q derived from Types", places[0].LocationType, POI.LocationTypeMealTakeaway)
+		}
+		if places[1].LocationType != POI.LocationTypeAny {
+			t.Errorf("LocationType = %q, want empty when Types has no meaningful primary", places[1].LocationType)
+		}
+	})
+
+	t.Run("a typed search keeps its searched-type stamp", func(t *testing.T) {
+		// Re-tagging typed searches is ReclassifyForCategory's job on the category
+		// paths; the parser must not start second-guessing it here.
+		places := parsePlacesSearchResponse(resp, POI.LocationTypeRestaurant, nil, map[string]bool{}, nil, nil)
+		if places[0].LocationType != POI.LocationTypeRestaurant {
+			t.Errorf("LocationType = %q, want the searched type %q", places[0].LocationType, POI.LocationTypeRestaurant)
+		}
+	})
+}
+
+// TestRestoreCachedDetailsPreservesLocationType covers the other half of the same bug: a
+// keyword result that still ends up untyped (no meaningful Types) must not blank out the
+// LocationType a category search already stored — restore only ever fills a gap.
+func TestRestoreCachedDetailsPreservesLocationType(t *testing.T) {
+	stored := storedPlace("near", time.Now())
+	stored.SetType(POI.LocationTypeRestaurant)
+
+	t.Run("an untyped rebuilt place recovers the stored type", func(t *testing.T) {
+		places := []POI.Place{{ID: "near"}}
+		restoreCachedDetails(places, map[string]POI.Place{"near": stored})
+		if places[0].LocationType != POI.LocationTypeRestaurant {
+			t.Errorf("LocationType = %q, want stored %q", places[0].LocationType, POI.LocationTypeRestaurant)
+		}
+	})
+
+	t.Run("a typed rebuilt place keeps its fresh type", func(t *testing.T) {
+		places := []POI.Place{{ID: "near", LocationType: POI.LocationTypeMealTakeaway}}
+		restoreCachedDetails(places, map[string]POI.Place{"near": stored})
+		if places[0].LocationType != POI.LocationTypeMealTakeaway {
+			t.Errorf("LocationType = %q, want fresh %q kept", places[0].LocationType, POI.LocationTypeMealTakeaway)
+		}
+	})
+}
+
 // TestRestoreCachedDetails pins the half of the optimisation that protects the data: the write
 // path is a blind upsert, so a place whose Details call was skipped must not be written back
 // stripped of the fields it was skipped because of.


### PR DESCRIPTION
## Problem

Keyword (brand) searches (`/v1/nearby-places`) query Google with `LocationTypeAny`, and `parsePlacesSearchResponse` stamps every result with the *searched* type — so keyword results are cached with `LocationType: ""`. The write path (`SetPlacesAddGeoLocationsForBrand`) is a blind upsert into the shared `placeDetails:{id}` records that category reads hydrate from, and `restoreCachedDetails` restores URL/Summary/Address/Hours but not LocationType. Net effect: every brand search wipes the type off previously typed records.

Observed downstream (OfferBee staging): a McDonald's row cached by an Eatery category search was served with `LocationType: ""` after brand searches rewrote its record, so the best-card ranking scored every card at its base rate — Chase Sapphire Reserve showed 1X at McDonald's instead of 3X dining.

## Fix (both changes gap-filling only)

- **`parsePlacesSearchResponse`**: when the searched type is `LocationTypeAny`, derive `LocationType` from `POI.PrimaryLocationType(place.Types)` — the same machinery `ReclassifyForCategory` already uses to re-tag places on category reads (#442). Google lists the most specific type first and umbrella types (`food`, `point_of_interest`, …) are skipped, so a McDonald's (`["meal_takeaway", "food", ...]`) comes out `meal_takeaway`. Typed searches keep their searched-type stamp — re-tagging those stays `ReclassifyForCategory`'s job.
- **`restoreCachedDetails`**: restore the stored `LocationType` when the rebuilt record has none — same "only ever fills a gap, never overwrites" rule the function already documents for the Details-sourced fields. Covers keyword results whose `Types` carry no meaningful primary.

## Safety

- Category geo buckets can't be poisoned: the brand write path never touches them, and `SetPlacesAddGeoLocations` already refuses unmapped types ("Refuse to guess a bucket").
- Empty/umbrella-only `Types` → `PrimaryLocationType` returns `""` → identical to today.
- Existing blank-typed records stay blank until a fresh search rewrites them; this stops new wipes at the source. (OfferBee's section-fallback covers the residue meanwhile.)

## Testing

- New: `TestParsePlacesSearchResponseKeywordDerivesLocationType` (keyword derives from Types; umbrella-only stays blank; typed search stamp unchanged), `TestRestoreCachedDetailsPreservesLocationType` (untyped rebuild recovers stored type; fresh type never overwritten). Both watched fail before the fix.
- `go build ./... && go vet ./iowrappers/ && go test ./...` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011BmBJ2x6b7V36vywSMrYDy